### PR TITLE
[#64] FIX : Empty상태에서 규칙 추가 시 화면반영 이슈 해결

### DIFF
--- a/Hous-iOS-release/Application/SceneDelegate.swift
+++ b/Hous-iOS-release/Application/SceneDelegate.swift
@@ -18,7 +18,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     let serviceProvider = ServiceProvider()
     let reactor = SplashReactor(provider: serviceProvider)
 
-//    window.rootViewController = HousTabbarViewController()
     window.rootViewController = SplashViewController(reactor)
     window.backgroundColor = .white
     window.makeKeyAndVisible()

--- a/Hous-iOS-release/Scene/MainHome/ViewControllers/MainHomeViewController.swift
+++ b/Hous-iOS-release/Scene/MainHome/ViewControllers/MainHomeViewController.swift
@@ -172,9 +172,8 @@ class MainHomeViewController: UIViewController {
 
   //MARK: Helpers
   private func bind() {
-    let viewWillAppear = rx.sentMessage(#selector(UIViewController.viewWillAppear(_:)))
-      .map { _ in }
-      .asSignal(onErrorJustReturn: ())
+    let viewWillAppear =
+    rx.RxViewWillAppear.asSignal()
     
     let input = MainHomeViewModel.Input(
       viewWillAppear: viewWillAppear,
@@ -213,6 +212,7 @@ class MainHomeViewController: UIViewController {
     }
     
     output.sections
+      .debug("이게 안불리는건가???")
       .drive(collectionView.rx.items(dataSource: dataSource))
       .disposed(by: disposeBag)
     
@@ -224,13 +224,6 @@ class MainHomeViewController: UIViewController {
         }
       })
       .disposed(by: disposeBag)
-  }
-}
-
-// Edit홈에
-extension MainHomeViewController {
-  @objc private func didPopRoomNameEditView() {
-    self.viewWillAppear.accept(())
   }
 }
 

--- a/Hous-iOS-release/Scene/MainHome/Views/Cells/MainHomeRulesCollectionViewCell.swift
+++ b/Hous-iOS-release/Scene/MainHome/Views/Cells/MainHomeRulesCollectionViewCell.swift
@@ -97,6 +97,9 @@ class MainHomeRulesCollectionViewCell: UICollectionViewCell {
       ourRulesStackView.isHidden = true
       ruleEmptyViewLabel.isHidden = false
       return
+    } else {
+      ourRulesStackView.isHidden = false
+      ruleEmptyViewLabel.isHidden = true
     }
     
     ourRulesStackView.subviews.forEach { $0.removeFromSuperview() }

--- a/Hous-iOS-release/Scene/OurRule/MainRuleView/Cells/KeyRulesTableViewCell.swift
+++ b/Hous-iOS-release/Scene/OurRule/MainRuleView/Cells/KeyRulesTableViewCell.swift
@@ -92,6 +92,8 @@ class KeyRulesTableViewCell: UITableViewCell {
     } else if ruleCount <= 3 {
       emptyNormalRulesLabel.isHidden = false // Only Normal Rule Empty
     } else {
+      ourRulesStackView.isHidden = false
+      ruleEmptyViewLabel.isHidden = true
       emptyNormalRulesLabel.isHidden = true
     }
     

--- a/Hous-iOS-release/Scene/OurRule/MainRuleView/OurRulesViewController.swift
+++ b/Hous-iOS-release/Scene/OurRule/MainRuleView/OurRulesViewController.swift
@@ -130,8 +130,9 @@ class OurRulesViewController: UIViewController {
         let ruleList = self.rulesWithIds.map { ruleWithIdViewModel in
           ruleWithIdViewModel.name
         }
-        let vc = EditRuleViewController(editViewRules: self.rulesWithIds, viewModel: EditRuleViewModel())
-//        let vc = AddRuleViewController(rules: ruleList, viewModel: AddRuleViewModel())
+//        let vc = DeleteRuleViewController(rules: self.rulesWithIds, viewModel: DeleteRuleViewModel())
+//        let vc = EditRuleViewController(editViewRules: self.rulesWithIds, viewModel: EditRuleViewModel())
+        let vc = AddRuleViewController(rules: ruleList, viewModel: AddRuleViewModel())
         vc.view.backgroundColor = .white
         self.navigationController?.pushViewController(vc, animated: true)
       })


### PR DESCRIPTION
## [#64] FIX : Empty상태에서 규칙 추가 시 화면반영 이슈 해결

## 🌱 작업한 내용
- 규칙이 없는 엠티뷰 상태에서 규칙 추가시에 기본 규칙뷰랑 메인홈에서 바로 반영이 안되는 이슈가 있었습니다
- empty view시에 대한 isHidden 처리만 해주고 그 외 아닐 때에 대한 처리가 없었어서 생긴 이슈였습니다


## 📮 관련 이슈

- Resolved: #64 
