### PR TITLE
[#91] FIX : 메인홈 방이름 변경 경고문구 이슈 해결

### DIFF
--- a/Hous-iOS-release/Scene/MainHome/ViewModels/EditHousNameViewModel.swift
+++ b/Hous-iOS-release/Scene/MainHome/ViewModels/EditHousNameViewModel.swift
@@ -35,10 +35,10 @@ final class EditHousNameViewModel: ViewModelType {
   func transform(input: Input) -> Output {
     
     let isValidText = input.roomName
-      .map { string -> Bool in
-        return string.count <= 8 || string.count > 0
+      .map { str -> Bool in
+        return str.count <= 8
       }
-      .asDriver()
+      .asDriver(onErrorJustReturn: false)
       
     
     let textCount = input.roomName.map({ [weak self] str -> String in


### PR DESCRIPTION
## [#91] FIX : 메인홈 방이름 변경 경고문구 이슈 해결

## 🌱 작업한 내용

- 메인홈 방이름 변경 경고문구 이슈 해결

## 🌱 PR Point
- 메인홈 방이름 변경 경고문구 이슈 해결


## 📮 관련 이슈

- Resolved: #91 
