### PR TITLE
[#107] FEAT : QA 메인홈에서 규칙배경 클릭시에도 화면전환

### DIFF
--- a/Hous-iOS-release/Scene/MainHome/ViewControllers/MainHomeViewController.swift
+++ b/Hous-iOS-release/Scene/MainHome/ViewControllers/MainHomeViewController.swift
@@ -130,15 +130,21 @@ class MainHomeViewController: LoadingBaseViewController {
       guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MainHomeRulesCollectionViewCell.className, for: indexPath) as? MainHomeRulesCollectionViewCell else { return UICollectionViewCell()
       }
       
-      cell.ourRulesArrowButton.rx.tap
-        .asDriver()
-        .drive(onNext: { [weak self] in
-          guard let self = self else { return }
-          let vc = OurRulesViewController(viewModel: RulesViewModel())
-          vc.view.backgroundColor = .white
-          self.navigationController?.pushViewController(vc, animated: true)
-        })
-        .disposed(by: cell.disposeBag)
+      Observable.merge(
+        cell.ourRulesBackgroundView.rx.tapGesture()
+          .when(.recognized)
+          .map{ _ in }
+          .asObservable(),
+        cell.ourRulesArrowButton.rx.tap.asObservable()
+      )
+      .asDriver(onErrorJustReturn: ())
+      .drive(onNext: { [weak self] in
+        guard let self = self else { return }
+        let vc = OurRulesViewController(viewModel: RulesViewModel())
+        vc.view.backgroundColor = .white
+        self.navigationController?.pushViewController(vc, animated: true)
+      })
+      .disposed(by: cell.disposeBag)
       
       cell.setHomeRulesCell(ourRules: todos.ourRules)
 

--- a/Hous-iOS-release/Scene/MainHome/Views/Cells/MainHomeRulesCollectionViewCell.swift
+++ b/Hous-iOS-release/Scene/MainHome/Views/Cells/MainHomeRulesCollectionViewCell.swift
@@ -21,7 +21,7 @@ class MainHomeRulesCollectionViewCell: UICollectionViewCell {
     $0.setImage(Images.icMoreOurRules.image, for: .normal)
   }
   
-  private let ourRulesBackgroundView = UIView().then {
+  let ourRulesBackgroundView = UIView().then {
     $0.backgroundColor = Colors.blueL2.color
     $0.layer.cornerRadius = 8
   }


### PR DESCRIPTION
## [#107 ] FEAT : QA 메인홈에서 규칙배경 클릭시에도 화면전환

## 🌱 작업한 내용
- 메인홈에서 규칙배경 클릭시에도 화면전환

## 🌱 PR Point
- TapGesture와 tap merge로 여러 클릭이벤트 한번에 받기

## 📮 관련 이슈

- Resolved: #107 
