### PR TITLE
[#192] FEAT : 탈퇴뷰 첫번째 뷰 - ConfirmRemoveProfileView

### DIFF
--- a/Hous-iOS-release.xcodeproj/project.pbxproj
+++ b/Hous-iOS-release.xcodeproj/project.pbxproj
@@ -278,6 +278,8 @@
 		B8DA060628E58B5A00C79B40 /* ProgressBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DA060528E58B5A00C79B40 /* ProgressBarView.swift */; };
 		B8DA060828E5A09300C79B40 /* ProgressBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DA060728E5A09300C79B40 /* ProgressBubbleView.swift */; };
 		B8E393712A1B81B50045F978 /* ConfirmRemoveProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E393702A1B81B50045F978 /* ConfirmRemoveProfileViewController.swift */; };
+		B8E393732A1BBCFE0045F978 /* ConfirmRemoveProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E393722A1BBCFE0045F978 /* ConfirmRemoveProfileView.swift */; };
+		B8E393752A1BBD0E0045F978 /* ConfirmRemoveProfileReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E393742A1BBD0E0045F978 /* ConfirmRemoveProfileReactor.swift */; };
 		B8FF4D8E290411A50087AD40 /* MemberTodoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FF4D8D290411A50087AD40 /* MemberTodoViewController.swift */; };
 		B8FF4D9029050CF00087AD40 /* MemberTodoViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FF4D8F29050CF00087AD40 /* MemberTodoViewReactor.swift */; };
 		B8FF4D92290515770087AD40 /* MemberRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FF4D91290515770087AD40 /* MemberRepository.swift */; };
@@ -593,6 +595,8 @@
 		B8DA060528E58B5A00C79B40 /* ProgressBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBarView.swift; sourceTree = "<group>"; };
 		B8DA060728E5A09300C79B40 /* ProgressBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBubbleView.swift; sourceTree = "<group>"; };
 		B8E393702A1B81B50045F978 /* ConfirmRemoveProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmRemoveProfileViewController.swift; sourceTree = "<group>"; };
+		B8E393722A1BBCFE0045F978 /* ConfirmRemoveProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmRemoveProfileView.swift; sourceTree = "<group>"; };
+		B8E393742A1BBD0E0045F978 /* ConfirmRemoveProfileReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmRemoveProfileReactor.swift; sourceTree = "<group>"; };
 		B8FF4D8D290411A50087AD40 /* MemberTodoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberTodoViewController.swift; sourceTree = "<group>"; };
 		B8FF4D8F29050CF00087AD40 /* MemberTodoViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberTodoViewReactor.swift; sourceTree = "<group>"; };
 		B8FF4D91290515770087AD40 /* MemberRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberRepository.swift; sourceTree = "<group>"; };
@@ -1627,6 +1631,8 @@
 			isa = PBXGroup;
 			children = (
 				B8E393702A1B81B50045F978 /* ConfirmRemoveProfileViewController.swift */,
+				B8E393722A1BBCFE0045F978 /* ConfirmRemoveProfileView.swift */,
+				B8E393742A1BBD0E0045F978 /* ConfirmRemoveProfileReactor.swift */,
 			);
 			path = ConfirmRemoveProfile;
 			sourceTree = "<group>";
@@ -1883,6 +1889,7 @@
 				B84EA6C128D61DEA00C92FCD /* NSObject+Extension.swift in Sources */,
 				B84EA6BF28D61C3300C92FCD /* TodoMainSection.swift in Sources */,
 				9B4EE80A29490747002F97C2 /* ProfileAlarmModel.swift in Sources */,
+				B8E393752A1BBD0E0045F978 /* ConfirmRemoveProfileReactor.swift in Sources */,
 				B856701028C894D300B49984 /* UIStackView+Extension.swift in Sources */,
 				B8555AC7291D067A00E943AE /* ByDayHeaderCollectionReusableView.swift in Sources */,
 				B591488C290D21A700618F26 /* UIViewController+Rx.swift in Sources */,
@@ -1909,6 +1916,7 @@
 				77EB721A292A1AE200032776 /* FilteredTodoReactor.swift in Sources */,
 				9BE2D4762941C30E00C6D7F7 /* UIDevice+Extension.swift in Sources */,
 				9B83201029196B09001EBDFE /* ProfileEditTextField.swift in Sources */,
+				B8E393732A1BBCFE0045F978 /* ConfirmRemoveProfileView.swift in Sources */,
 				B5914885290BC2D200618F26 /* RulesViewModel.swift in Sources */,
 				B8D066E828FAA74600A99907 /* FilteredTodoView.swift in Sources */,
 				B595FFF128D5992F00F6B2E4 /* EditHousNameViewController.swift in Sources */,

--- a/Hous-iOS-release.xcodeproj/project.pbxproj
+++ b/Hous-iOS-release.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 		B8DA060428E543C800C79B40 /* CreateNewRoomViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DA060328E543C800C79B40 /* CreateNewRoomViewReactor.swift */; };
 		B8DA060628E58B5A00C79B40 /* ProgressBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DA060528E58B5A00C79B40 /* ProgressBarView.swift */; };
 		B8DA060828E5A09300C79B40 /* ProgressBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DA060728E5A09300C79B40 /* ProgressBubbleView.swift */; };
+		B8E393712A1B81B50045F978 /* ConfirmRemoveProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E393702A1B81B50045F978 /* ConfirmRemoveProfileViewController.swift */; };
 		B8FF4D8E290411A50087AD40 /* MemberTodoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FF4D8D290411A50087AD40 /* MemberTodoViewController.swift */; };
 		B8FF4D9029050CF00087AD40 /* MemberTodoViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FF4D8F29050CF00087AD40 /* MemberTodoViewReactor.swift */; };
 		B8FF4D92290515770087AD40 /* MemberRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FF4D91290515770087AD40 /* MemberRepository.swift */; };
@@ -591,6 +592,7 @@
 		B8DA060328E543C800C79B40 /* CreateNewRoomViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateNewRoomViewReactor.swift; sourceTree = "<group>"; };
 		B8DA060528E58B5A00C79B40 /* ProgressBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBarView.swift; sourceTree = "<group>"; };
 		B8DA060728E5A09300C79B40 /* ProgressBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBubbleView.swift; sourceTree = "<group>"; };
+		B8E393702A1B81B50045F978 /* ConfirmRemoveProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmRemoveProfileViewController.swift; sourceTree = "<group>"; };
 		B8FF4D8D290411A50087AD40 /* MemberTodoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberTodoViewController.swift; sourceTree = "<group>"; };
 		B8FF4D8F29050CF00087AD40 /* MemberTodoViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberTodoViewReactor.swift; sourceTree = "<group>"; };
 		B8FF4D91290515770087AD40 /* MemberRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberRepository.swift; sourceTree = "<group>"; };
@@ -1406,6 +1408,7 @@
 		B856701528C99FEC00B49984 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
+				B8E3936E2A1B814D0045F978 /* RemoveProfile */,
 				B880F5C2293C902F00E888BC /* Resign */,
 				B84EA6D828DD7F1200C92FCD /* EnterInfo */,
 				B84EA6D928DD7F1B00C92FCD /* Paging */,
@@ -1610,6 +1613,22 @@
 				B8555A9F2917D22D00E943AE /* ByDayTodoViewController.swift */,
 			);
 			path = Controller;
+			sourceTree = "<group>";
+		};
+		B8E3936E2A1B814D0045F978 /* RemoveProfile */ = {
+			isa = PBXGroup;
+			children = (
+				B8E3936F2A1B81A10045F978 /* ConfirmRemoveProfile */,
+			);
+			path = RemoveProfile;
+			sourceTree = "<group>";
+		};
+		B8E3936F2A1B81A10045F978 /* ConfirmRemoveProfile */ = {
+			isa = PBXGroup;
+			children = (
+				B8E393702A1B81B50045F978 /* ConfirmRemoveProfileViewController.swift */,
+			);
+			path = ConfirmRemoveProfile;
 			sourceTree = "<group>";
 		};
 		B8FF4D8C29040DDE0087AD40 /* ViewModel */ = {
@@ -1854,6 +1873,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9B83200E2919408A001EBDFE /* ProfileEditNavtigationView.swift in Sources */,
+				B8E393712A1B81B50045F978 /* ConfirmRemoveProfileViewController.swift in Sources */,
 				B8B56B9F28E2DEBF00FC99DA /* EnterRoomViewReactor.swift in Sources */,
 				9BF9AD6D291E0A58006A0BDE /* ProfileEditBackButton.swift in Sources */,
 				7706800E28E043A40082A7E7 /* SignInViewController.swift in Sources */,

--- a/Hous-iOS-release/Global/UIComponent/NavigationBarView.swift
+++ b/Hous-iOS-release/Global/UIComponent/NavigationBarView.swift
@@ -33,6 +33,10 @@ class NavBarWithBackButtonView: UIView {
     $0.titleLabel?.textAlignment = .right
   }
 
+  private let grayLineView = UIView().then {
+    $0.backgroundColor = Colors.g1.color
+  }
+
   var title: String = "" {
     didSet {
       titleLabel.text = title
@@ -53,10 +57,11 @@ class NavBarWithBackButtonView: UIView {
 
   init(title: String = "",
        rightButtonText: String = "",
-       rightButtonImage: UIImage? = nil
+       rightButtonImage: UIImage? = nil,
+       isSeparatorLineHidden: Bool = true
   ) {
     super.init(frame: .zero)
-    configUI(title, rightButtonText, rightButtonImage)
+    configUI(title, rightButtonText, rightButtonImage, isSeparatorLineHidden)
     render()
 
   }
@@ -68,18 +73,20 @@ class NavBarWithBackButtonView: UIView {
   private func configUI(
     _ title: String,
     _ rightButtonText: String,
-    _ rightButtonImage: UIImage?
+    _ rightButtonImage: UIImage?,
+    _ isSeparatorLineHidden: Bool
   ) {
     titleLabel.text = title
     rightButton.setTitle(rightButtonText, for: .normal)
     rightButton.setImage(rightButtonImage, for: .normal)
+    isSeparatorLineHidden ? (grayLineView.isHidden = true) : (grayLineView.isHidden = false)
   }
 
   private func render() {
 
     backgroundColor = Colors.white.color
 
-    addSubViews([backButton, titleLabel, rightButton])
+    addSubViews([backButton, titleLabel, rightButton, grayLineView])
 
     backButton.snp.makeConstraints { make in
       make.size.equalTo(24)
@@ -95,6 +102,11 @@ class NavBarWithBackButtonView: UIView {
       make.size.greaterThanOrEqualTo(24)
       make.centerY.equalToSuperview()
       make.trailing.equalToSuperview().inset(24)
+    }
+
+    grayLineView.snp.makeConstraints { make in
+      make.leading.trailing.bottom.equalToSuperview()
+      make.height.equalTo(1)
     }
   }
 

--- a/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileReactor.swift
+++ b/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileReactor.swift
@@ -17,13 +17,15 @@ final class ConfirmRemoveProfileReactor: ReactorKit.Reactor {
 
   enum Mutation {
     case setIsCheckButtonSelected(Bool)
-    case setIsRemoveButtonActivated(Bool?)
+    case setIsRemoveButtonEnabled(Bool)
+    case setIsRemoveButtonClicked(Bool)
     case setError(String?)
   }
 
   struct State {
-    var isCheckButtonSelected: Bool = false
-    var isRemoveButtonActivated: Bool? = false
+    @Pulse var isCheckButtonSelected: Bool = false
+    @Pulse var isRemoveButtonEnabled: Bool = false
+    @Pulse var isRemoveButtonClicked: Bool = false
 
     var error: String? = nil
   }
@@ -34,9 +36,17 @@ final class ConfirmRemoveProfileReactor: ReactorKit.Reactor {
 
     switch action {
     case .didTapCheck:
-      return .empty()
+
+      let newCheckFlag = !currentState.isCheckButtonSelected
+      return .concat([
+        .just(Mutation.setIsCheckButtonSelected(newCheckFlag)),
+        .just(Mutation.setIsRemoveButtonEnabled(newCheckFlag))
+      ])
+
     case .didTapRemoveProfile:
-      return .empty()
+      return .just(Mutation.setIsRemoveButtonClicked(
+        !currentState.isRemoveButtonClicked
+      ))
     }
   }
 
@@ -47,10 +57,12 @@ final class ConfirmRemoveProfileReactor: ReactorKit.Reactor {
     switch mutation {
     case let .setIsCheckButtonSelected(flag):
       newState.isCheckButtonSelected = flag
-    case let .setIsRemoveButtonActivated(flag):
-      newState.isRemoveButtonActivated = flag
+    case let .setIsRemoveButtonEnabled(flag):
+      newState.isRemoveButtonEnabled = flag
     case let .setError(error):
       newState.error = error
+    case let .setIsRemoveButtonClicked(flag):
+      newState.isRemoveButtonClicked = flag
     }
 
     return newState

--- a/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileReactor.swift
+++ b/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileReactor.swift
@@ -1,0 +1,8 @@
+//
+//  ConfirmRemoveProfileReactor.swift
+//  Hous-iOS-release
+//
+//  Created by 김지현 on 2023/05/23.
+//
+
+import Foundation

--- a/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileReactor.swift
+++ b/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileReactor.swift
@@ -6,3 +6,55 @@
 //
 
 import Foundation
+import ReactorKit
+
+final class ConfirmRemoveProfileReactor: ReactorKit.Reactor {
+
+  enum Action {
+    case didTapCheck
+    case didTapRemoveProfile
+  }
+
+  enum Mutation {
+    case setIsCheckButtonSelected(Bool)
+    case setIsRemoveButtonActivated(Bool?)
+    case setError(String?)
+  }
+
+  struct State {
+    var isCheckButtonSelected: Bool = false
+    var isRemoveButtonActivated: Bool? = false
+
+    var error: String? = nil
+  }
+
+  let initialState = State()
+
+  func mutate(action: Action) -> Observable<Mutation> {
+
+    switch action {
+    case .didTapCheck:
+      return .empty()
+    case .didTapRemoveProfile:
+      return .empty()
+    }
+  }
+
+  func reduce(state: State, mutation: Mutation) -> State {
+
+    var newState = state
+
+    switch mutation {
+    case let .setIsCheckButtonSelected(flag):
+      newState.isCheckButtonSelected = flag
+    case let .setIsRemoveButtonActivated(flag):
+      newState.isRemoveButtonActivated = flag
+    case let .setError(error):
+      newState.error = error
+    }
+
+    return newState
+  }
+
+
+}

--- a/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileView.swift
+++ b/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileView.swift
@@ -5,4 +5,96 @@
 //  Created by 김지현 on 2023/05/23.
 //
 
-import Foundation
+import UIKit
+import HousUIComponent
+
+final class ConfirmRemoveProfileView: UIView {
+
+  enum Size {
+    static let navigationBarHeight = 64
+    static let guideLabel: Double = 13
+  }
+
+  let navigationBarView = NavBarWithBackButtonView(
+    title: "회원 탈퇴",
+    rightButtonText: "",
+    isSeparatorLineHidden: false)
+
+  let stackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.alignment = .fill
+    $0.distribution = .fillProportionally
+    $0.spacing = 24
+  }
+
+  let titleLabel = UILabel().then {
+    $0.text = "정말 탈퇴하시겠어요?"
+    $0.textColor = Colors.g7.color
+    $0.font = Fonts.SpoqaHanSansNeo.bold.font(size: 18)
+    $0.textAlignment = .center
+  }
+
+  let imageView = UIImageView().then {
+    $0.image = Images.resign.image
+    $0.makeRounded(cornerRadius: 8)
+    $0.clipsToBounds = true
+  }
+
+  let guideLabel = UILabel().then {
+
+    let style = NSMutableParagraphStyle()
+    let lineheight = Size.guideLabel * 1.84
+    style.minimumLineHeight = lineheight
+    style.maximumLineHeight = lineheight
+
+    $0.attributedText = NSAttributedString(
+      string: "회원을 탈퇴하면 탈퇴 신청 즉시\n회원의 개인정보는 삭제되며 복구할 수 없습니다.",
+      attributes: [
+        .paragraphStyle: style,
+        .baselineOffset: (lineheight - Size.guideLabel) / 4
+      ])
+    $0.textColor = Colors.g4.color
+    $0.numberOfLines = 2
+    $0.font = Fonts.SpoqaHanSansNeo.medium.font(size: Size.guideLabel)
+    $0.textAlignment = .center
+  }
+
+  let confirmButton = CheckButton(.confirmRemoveProfile).then {
+    $0.isSelected = false
+  }
+
+  var removeProfileButton = OnboardingButton(.leaveProfile).then {
+    $0.isEnabled = false
+  }
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    configUI()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  private func configUI() {
+
+    addSubViews([navigationBarView, stackView, removeProfileButton])
+    stackView.addArrangedSubviews(titleLabel, imageView, guideLabel, confirmButton)
+
+    navigationBarView.snp.makeConstraints { make in
+      make.top.equalTo(safeAreaLayoutGuide)
+      make.leading.trailing.equalToSuperview()
+      make.height.equalTo(Size.navigationBarHeight)
+    }
+
+    stackView.snp.makeConstraints { make in
+      make.trailing.leading.equalToSuperview().inset(28)
+      make.center.equalToSuperview()
+    }
+
+    removeProfileButton.snp.makeConstraints { make in
+      make.leading.trailing.bottom.equalToSuperview()
+      make.height.equalTo(86)
+    }
+  }
+}

--- a/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileView.swift
+++ b/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileView.swift
@@ -1,0 +1,8 @@
+//
+//  ConfirmRemoveProfileView.swift
+//  Hous-iOS-release
+//
+//  Created by 김지현 on 2023/05/23.
+//
+
+import Foundation

--- a/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileViewController.swift
+++ b/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileViewController.swift
@@ -6,13 +6,22 @@
 //
 
 import UIKit
-import Then
+import ReactorKit
 
-import HousUIComponent
+final class ConfirmRemoveProfileViewController: UIViewController, ReactorKit.View {
 
-final class ConfirmRemoveProfileViewController: UIViewController {
-
+  typealias Reactor = ConfirmRemoveProfileReactor
+  var disposeBag = DisposeBag()
   var mainView = ConfirmRemoveProfileView()
+
+  init(_ reactor: Reactor) {
+    super.init(nibName: nil, bundle: nil)
+    self.reactor = reactor
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
 
   override func loadView() {
     self.view = mainView
@@ -27,6 +36,13 @@ final class ConfirmRemoveProfileViewController: UIViewController {
     self.view.backgroundColor = Colors.white.color
     navigationController?.navigationBar.isHidden = true
     mainView.navigationBarView.delegate = self
+  }
+}
+
+extension ConfirmRemoveProfileViewController {
+
+  func bind(reactor: Reactor) {
+    // bindaction
   }
 }
 

--- a/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileViewController.swift
+++ b/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileViewController.swift
@@ -42,7 +42,42 @@ final class ConfirmRemoveProfileViewController: UIViewController, ReactorKit.Vie
 extension ConfirmRemoveProfileViewController {
 
   func bind(reactor: Reactor) {
-    // bindaction
+    bindAction(reactor)
+    bindState(reactor)
+  }
+
+  private func bindAction(_ reactor: Reactor) {
+    mainView.confirmButton.rx.tap
+      .map { Reactor.Action.didTapCheck }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+
+    mainView.removeProfileButton.rx.tap
+      .map { Reactor.Action.didTapRemoveProfile }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+  }
+
+  private func bindState(_ reactor: Reactor) {
+
+    reactor.pulse(\.$isCheckButtonSelected)
+      .asDriver(onErrorJustReturn: false)
+      .drive(mainView.confirmButton.rx.isSelected)
+      .disposed(by: disposeBag)
+
+    reactor.pulse(\.$isRemoveButtonEnabled)
+      .asDriver(onErrorJustReturn: false)
+      .drive(mainView.removeProfileButton.rx.isEnabled)
+      .disposed(by: disposeBag)
+
+    reactor.pulse(\.$isRemoveButtonClicked)
+      .asDriver(onErrorJustReturn: false)
+      .drive(onNext: self.pushFeedbackView)
+      .disposed(by: disposeBag)
+  }
+
+  private func pushFeedbackView(_ success: Bool) {
+    print("Click")
   }
 }
 

--- a/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileViewController.swift
+++ b/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileViewController.swift
@@ -61,26 +61,8 @@ final class ConfirmRemoveProfileViewController: UIViewController {
     $0.textAlignment = .center
   }
 
-  let confirmButton = UIButton(configuration: .plain()).then {
-
-    var attrString = AttributedString("탈퇴하겠습니다")
-    attrString.font = Fonts.SpoqaHanSansNeo.medium.font(size: 13)
-    $0.configuration?.attributedTitle = attrString
-    $0.configuration?.baseBackgroundColor = Colors.white.color
-    $0.configuration?.imagePlacement = .leading
-    $0.configuration?.imagePadding = 4
-    $0.configurationUpdateHandler = { btn in
-      switch btn.state {
-      case .normal:
-        btn.configuration?.baseForegroundColor = Colors.redB1.color
-        btn.configuration?.image = Images.icCheckNotOnboardSetting.image
-      case .selected:
-        btn.configuration?.baseForegroundColor = Colors.red.color
-        btn.configuration?.image = Images.icCheckYesOnboardSetting.image
-      default:
-        break
-      }
-    }
+  let confirmButton = CheckButton(.confirmRemoveProfile).then {
+    $0.isSelected = false
   }
 
   var removeProfileButton = OnboardingButton(.leaveProfile).then {

--- a/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileViewController.swift
+++ b/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileViewController.swift
@@ -1,0 +1,130 @@
+//
+//  ConfirmRemoveProfileViewController.swift
+//  Hous-iOS-release
+//
+//  Created by 김지현 on 2023/05/22.
+//
+
+import UIKit
+import Then
+
+import HousUIComponent
+
+final class ConfirmRemoveProfileViewController: UIViewController {
+
+  enum Size {
+    static let navigationBarHeight = 64
+    static let guideLabel: Double = 13
+  }
+
+  let navigationBarView = NavBarWithBackButtonView(
+    title: "회원 탈퇴",
+    rightButtonText: "",
+    isSeparatorLineHidden: false)
+
+  let stackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.alignment = .fill
+    $0.distribution = .fillProportionally
+    $0.spacing = 24
+  }
+
+  let titleLabel = UILabel().then {
+    $0.text = "정말 탈퇴하시겠어요?"
+    $0.textColor = Colors.g7.color
+    $0.font = Fonts.SpoqaHanSansNeo.bold.font(size: 18)
+    $0.textAlignment = .center
+  }
+
+  let imageView = UIImageView().then {
+    $0.image = Images.resign.image
+    $0.makeRounded(cornerRadius: 8)
+    $0.clipsToBounds = true
+  }
+
+  let guideLabel = UILabel().then {
+
+    let style = NSMutableParagraphStyle()
+    let lineheight = Size.guideLabel * 1.84
+    style.minimumLineHeight = lineheight
+    style.maximumLineHeight = lineheight
+
+    $0.attributedText = NSAttributedString(
+      string: "회원을 탈퇴하면 탈퇴 신청 즉시\n회원의 개인정보는 삭제되며 복구할 수 없습니다.",
+      attributes: [
+        .paragraphStyle: style,
+        .baselineOffset: (lineheight - Size.guideLabel) / 4
+      ])
+    $0.textColor = Colors.g4.color
+    $0.numberOfLines = 2
+    $0.font = Fonts.SpoqaHanSansNeo.medium.font(size: Size.guideLabel)
+    $0.textAlignment = .center
+  }
+
+  let confirmButton = UIButton(configuration: .plain()).then {
+
+    var attrString = AttributedString("탈퇴하겠습니다")
+    attrString.font = Fonts.SpoqaHanSansNeo.medium.font(size: 13)
+    $0.configuration?.attributedTitle = attrString
+    $0.configuration?.baseBackgroundColor = Colors.white.color
+    $0.configuration?.imagePlacement = .leading
+    $0.configuration?.imagePadding = 4
+    $0.configurationUpdateHandler = { btn in
+      switch btn.state {
+      case .normal:
+        btn.configuration?.baseForegroundColor = Colors.redB1.color
+        btn.configuration?.image = Images.icCheckNotOnboardSetting.image
+      case .selected:
+        btn.configuration?.baseForegroundColor = Colors.red.color
+        btn.configuration?.image = Images.icCheckYesOnboardSetting.image
+      default:
+        break
+      }
+    }
+  }
+
+  var removeProfileButton = OnboardingButton(.leaveProfile).then {
+    $0.isEnabled = false
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    setup()
+    configUI()
+  }
+
+  private func setup() {
+    self.view.backgroundColor = Colors.white.color
+    navigationController?.navigationBar.isHidden = true
+    navigationBarView.delegate = self
+  }
+
+  private func configUI() {
+
+    self.view.addSubViews([navigationBarView, stackView, removeProfileButton])
+    stackView.addArrangedSubviews(titleLabel, imageView, guideLabel, confirmButton)
+
+    navigationBarView.snp.makeConstraints { make in
+      make.top.equalTo(self.view.safeAreaLayoutGuide)
+      make.leading.trailing.equalToSuperview()
+      make.height.equalTo(Size.navigationBarHeight)
+    }
+
+    stackView.snp.makeConstraints { make in
+      make.trailing.leading.equalToSuperview().inset(28)
+      make.center.equalToSuperview()
+    }
+
+    removeProfileButton.snp.makeConstraints { make in
+      make.leading.trailing.bottom.equalToSuperview()
+      make.height.equalTo(86)
+    }
+  }
+}
+
+extension ConfirmRemoveProfileViewController: NavBarWithBackButtonViewDelegate {
+
+  func backButtonDidTapped() {
+    navigationController?.popViewController(animated: true)
+  }
+}

--- a/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileViewController.swift
+++ b/Hous-iOS-release/Scene/Onboarding/RemoveProfile/ConfirmRemoveProfile/ConfirmRemoveProfileViewController.swift
@@ -12,95 +12,21 @@ import HousUIComponent
 
 final class ConfirmRemoveProfileViewController: UIViewController {
 
-  enum Size {
-    static let navigationBarHeight = 64
-    static let guideLabel: Double = 13
-  }
+  var mainView = ConfirmRemoveProfileView()
 
-  let navigationBarView = NavBarWithBackButtonView(
-    title: "회원 탈퇴",
-    rightButtonText: "",
-    isSeparatorLineHidden: false)
-
-  let stackView = UIStackView().then {
-    $0.axis = .vertical
-    $0.alignment = .fill
-    $0.distribution = .fillProportionally
-    $0.spacing = 24
-  }
-
-  let titleLabel = UILabel().then {
-    $0.text = "정말 탈퇴하시겠어요?"
-    $0.textColor = Colors.g7.color
-    $0.font = Fonts.SpoqaHanSansNeo.bold.font(size: 18)
-    $0.textAlignment = .center
-  }
-
-  let imageView = UIImageView().then {
-    $0.image = Images.resign.image
-    $0.makeRounded(cornerRadius: 8)
-    $0.clipsToBounds = true
-  }
-
-  let guideLabel = UILabel().then {
-
-    let style = NSMutableParagraphStyle()
-    let lineheight = Size.guideLabel * 1.84
-    style.minimumLineHeight = lineheight
-    style.maximumLineHeight = lineheight
-
-    $0.attributedText = NSAttributedString(
-      string: "회원을 탈퇴하면 탈퇴 신청 즉시\n회원의 개인정보는 삭제되며 복구할 수 없습니다.",
-      attributes: [
-        .paragraphStyle: style,
-        .baselineOffset: (lineheight - Size.guideLabel) / 4
-      ])
-    $0.textColor = Colors.g4.color
-    $0.numberOfLines = 2
-    $0.font = Fonts.SpoqaHanSansNeo.medium.font(size: Size.guideLabel)
-    $0.textAlignment = .center
-  }
-
-  let confirmButton = CheckButton(.confirmRemoveProfile).then {
-    $0.isSelected = false
-  }
-
-  var removeProfileButton = OnboardingButton(.leaveProfile).then {
-    $0.isEnabled = false
+  override func loadView() {
+    self.view = mainView
   }
 
   override func viewDidLoad() {
     super.viewDidLoad()
     setup()
-    configUI()
   }
 
   private func setup() {
     self.view.backgroundColor = Colors.white.color
     navigationController?.navigationBar.isHidden = true
-    navigationBarView.delegate = self
-  }
-
-  private func configUI() {
-
-    self.view.addSubViews([navigationBarView, stackView, removeProfileButton])
-    stackView.addArrangedSubviews(titleLabel, imageView, guideLabel, confirmButton)
-
-    navigationBarView.snp.makeConstraints { make in
-      make.top.equalTo(self.view.safeAreaLayoutGuide)
-      make.leading.trailing.equalToSuperview()
-      make.height.equalTo(Size.navigationBarHeight)
-    }
-
-    stackView.snp.makeConstraints { make in
-      make.trailing.leading.equalToSuperview().inset(28)
-      make.center.equalToSuperview()
-    }
-
-    removeProfileButton.snp.makeConstraints { make in
-      make.leading.trailing.bottom.equalToSuperview()
-      make.height.equalTo(86)
-    }
+    mainView.navigationBarView.delegate = self
   }
 }
 

--- a/Hous-iOS-release/Scene/Profile/View/ViewController/ProfileSettingViewController.swift
+++ b/Hous-iOS-release/Scene/Profile/View/ViewController/ProfileSettingViewController.swift
@@ -328,9 +328,9 @@ extension ProfileSettingViewController {
 
   private func presentResignViewController() {
     let provider = ServiceProvider()
-    let reactor = ResignViewReactor(provider: provider)
-    let resignVC = ResignViewController(reactor)
-    navigationController?.pushViewController(resignVC, animated: true)
+    // let reactor = ResignViewReactor(provider: provider)
+    let removeProfileVC = ConfirmRemoveProfileViewController()
+    navigationController?.pushViewController(removeProfileVC, animated: true)
   }
 
   private func presentLeaveViewController() {

--- a/Hous-iOS-release/Scene/Profile/View/ViewController/ProfileSettingViewController.swift
+++ b/Hous-iOS-release/Scene/Profile/View/ViewController/ProfileSettingViewController.swift
@@ -328,8 +328,8 @@ extension ProfileSettingViewController {
 
   private func presentResignViewController() {
     let provider = ServiceProvider()
-    // let reactor = ResignViewReactor(provider: provider)
-    let removeProfileVC = ConfirmRemoveProfileViewController()
+    let reactor = ConfirmRemoveProfileReactor()
+    let removeProfileVC = ConfirmRemoveProfileViewController(reactor)
     navigationController?.pushViewController(removeProfileVC, animated: true)
   }
 

--- a/HousUIComponent/Sources/HousButton/BasicButton.swift
+++ b/HousUIComponent/Sources/HousButton/BasicButton.swift
@@ -10,7 +10,7 @@ import AssetKit
 
 public final class BasicButton: UIButton {
 
-  init(_ type: Button.Basic) {
+  public init(_ type: Button.Basic) {
     super.init(frame: .zero)
     configUI(type)
   }

--- a/HousUIComponent/Sources/HousButton/CheckButton.swift
+++ b/HousUIComponent/Sources/HousButton/CheckButton.swift
@@ -1,0 +1,48 @@
+//
+//  CheckButton.swift
+//  
+//
+//  Created by 김지현 on 2023/05/22.
+//
+
+import UIKit
+import AssetKit
+
+public final class CheckButton: UIButton {
+
+    public init(_ type: Button.Check) {
+        super.init(frame: .zero)
+        configUI(type)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func configUI(_ type: Button.Check) {
+        configuration = .plain()
+
+        var attrString = AttributedString(type.title)
+        attrString.font = Fonts.SpoqaHanSansNeo.medium.font(size: 13)
+        configuration?.attributedTitle = attrString
+
+        configuration?.baseBackgroundColor = Colors.white.color
+        configuration?.imagePlacement = .leading
+        configuration?.imagePadding = 4
+
+        configurationUpdateHandler = { btn in
+            switch btn.state {
+            case .selected:
+                btn.configuration?.baseForegroundColor = type.activeTitleColor
+                btn.configuration?.image = Images.icCheckYesOnboardSetting.image
+            case .normal:
+                btn.configuration?.baseForegroundColor = type.disabledTitleColor
+                btn.configuration?.image = Images.icCheckNotOnboardSetting.image
+            default:
+                break
+            }
+        }
+
+    }
+
+}

--- a/HousUIComponent/Sources/HousButton/Constant.swift
+++ b/HousUIComponent/Sources/HousButton/Constant.swift
@@ -9,9 +9,9 @@ import UIKit
 import AssetKit
 
 protocol ButtonCommonProtocol {
-    var activeBackgroundColor: UIColor { get }
+    var activeBackgroundColor: UIColor? { get }
     var disabledBackgroundColor: UIColor? { get }
-    var activeTitleColor: UIColor { get }
+    var activeTitleColor: UIColor? { get }
     var disabledTitleColor: UIColor? { get }
     var title: String { get }
 }
@@ -21,7 +21,7 @@ public enum Button {
     public enum Onboarding: ButtonCommonProtocol {
         case next, createRoom, enterRoom, start, toStart, leaveProfile
 
-        var activeBackgroundColor: UIColor {
+        var activeBackgroundColor: UIColor? {
             switch self {
             case .next, .createRoom, .enterRoom, .start, .toStart:
                 return Colors.blue.color
@@ -39,7 +39,7 @@ public enum Button {
             }
         }
 
-        var activeTitleColor: UIColor {
+        var activeTitleColor: UIColor? {
             return Colors.white.color
         }
 
@@ -70,7 +70,7 @@ extension Button {
     public enum Basic: ButtonCommonProtocol {
         case kakao, apple, save, retry
 
-        var activeBackgroundColor: UIColor {
+        var activeBackgroundColor: UIColor? {
             switch self {
             case .kakao:
                 return Colors.kakaoYellow.color
@@ -85,7 +85,7 @@ extension Button {
 
         var disabledBackgroundColor: UIColor? { return nil }
 
-        var activeTitleColor: UIColor {
+        var activeTitleColor: UIColor? {
             switch self {
             case .kakao:
                 return Colors.kakaoBrown.color
@@ -110,4 +110,42 @@ extension Button {
         }
     }
 
+}
+
+extension Button {
+
+    public enum Check: ButtonCommonProtocol {
+        case confirmRemoveProfile, comfirmFeedback
+
+        var activeBackgroundColor: UIColor? { return nil }
+
+        var disabledBackgroundColor: UIColor? { return nil }
+
+        var activeTitleColor: UIColor? {
+            switch self {
+            case .confirmRemoveProfile:
+                return Colors.red.color
+            case .comfirmFeedback:
+                return Colors.blue.color
+            }
+        }
+
+        var disabledTitleColor: UIColor? {
+            switch self {
+            case .confirmRemoveProfile:
+                return Colors.redB1.color
+            case .comfirmFeedback:
+                return Colors.blueL1.color
+            }
+        }
+
+        var title: String {
+            switch self {
+            case .confirmRemoveProfile:
+                return "탈퇴하겠습니다"
+            case .comfirmFeedback:
+                return "동의합니다."
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 🌱 작업한 내용

- 탈퇴뷰에서 쓰이는 CheckButton 모듈화
- 네비게이션바 밑에 Separator 라인이 있는 곳도 있고 없는 곳도 있더라구요, 생성자에 isSeparatorHidden 파라미터 추가해놨습니다. 지정 안하면 숨겨져있는거임
- ConfirmRemoveProfileView 완성했습니다.

## 🌱 PR Point

- @SuwonPabby profile setting view Navigation bar 따로 커스텀해놨던데, 제가 만들어놓은 네비게이션 바로 변경 부탁함니당!

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| ConfirmRemoveProfileView | ![IMG_B7DB983BA93D-1](https://github.com/Hous-Release/hous-iOS/assets/59338503/e5ac465c-1897-485a-8e7a-961f1c86dbb0) |

## 📮 관련 이슈

- Resolved: #192 
