### PR TITLE
[#195] FEAT : Rule바텀시트 구현

### DIFF
--- a/BottomSheetKit/Sources/BottomSheetKit/BottomSheetAction.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/BottomSheetAction.swift
@@ -17,3 +17,13 @@ protocol BottomSheetAction {
     var view: T { get set }
     
 }
+
+extension BottomSheetAction {
+    func sendAction(_ action: DidBottomSheetActionType) {
+        completeAction?(action)
+    }
+
+    func cancel() {
+        completeAction?(.cancel)
+    }
+}

--- a/BottomSheetKit/Sources/BottomSheetKit/BottomSheetAction.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/BottomSheetAction.swift
@@ -5,12 +5,15 @@
 //  Created by 김호세 on 2022/11/10.
 //
 
-import Foundation
+import UIKit
 
 public typealias CompleteBottomSheetAction = ((DidBottomSheetActionType) -> Void)
 
 protocol BottomSheetAction {
-  func sendAction(_ action: DidBottomSheetActionType)
-  func cancel()
-  var completeAction: CompleteBottomSheetAction? { get }
+    associatedtype T: UIView
+    func sendAction(_ action: DidBottomSheetActionType)
+    func cancel()
+    var completeAction: CompleteBottomSheetAction? { get }
+    var view: T { get set }
+    
 }

--- a/BottomSheetKit/Sources/BottomSheetKit/BottomSheetKit+.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/BottomSheetKit+.swift
@@ -133,7 +133,7 @@ public extension UIViewController {
       vc.modalTransitionStyle = .crossDissolve
       vc.modalPresentationStyle = .overFullScreen
       present(vc, animated: true)
-    case .RuleType(let model):
+    case .ruleType(let model):
         let view = RuleBottomSheetView(model: model)
         let bottomSheetAction = RuleBottomSheetAction(view: view)
         guard let viewController = RuleBottomSheetViewController(action: bottomSheetAction) else { return }

--- a/BottomSheetKit/Sources/BottomSheetKit/BottomSheetKit+.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/BottomSheetKit+.swift
@@ -136,7 +136,7 @@ public extension UIViewController {
     case .RuleType(let model):
         let view = RuleBottomSheetView(model: model)
         let bottomSheetAction = RuleBottomSheetAction(view: view)
-        let viewController = RuleBottomSheetViewController(action: bottomSheetAction)
+        guard let viewController = RuleBottomSheetViewController(action: bottomSheetAction) else { return }
 
         bottomSheetAction.completeAction = { actionType in
             completion?(actionType)

--- a/BottomSheetKit/Sources/BottomSheetKit/BottomSheetKit+.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/BottomSheetKit+.swift
@@ -133,7 +133,19 @@ public extension UIViewController {
       vc.modalTransitionStyle = .crossDissolve
       vc.modalPresentationStyle = .overFullScreen
       present(vc, animated: true)
+    case .RuleType(let model):
+        let view = RuleBottomSheetView(model: model)
+        let bottomSheetAction = RuleBottomSheetAction(view: view)
+        let viewController = RuleBottomSheetViewController(action: bottomSheetAction)
 
+        bottomSheetAction.completeAction = { actionType in
+            completion?(actionType)
+        }
+
+        viewController.modalPresentationStyle = .overFullScreen
+        present(viewController, animated: false) {
+            viewController.showBottomSheetWithAnimation()
+        }
     }
 
   }

--- a/BottomSheetKit/Sources/BottomSheetKit/DefaultBottomSheet/DefaultBottomSheetAction.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/DefaultBottomSheet/DefaultBottomSheetAction.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class DefaultBottomSheetAction: BottomSheetAction {
 
-  let view: DefaultBottomSheetView
+  var view: DefaultBottomSheetView
   var completeAction: CompleteBottomSheetAction?
 
   init(view: DefaultBottomSheetView) { self.view = view }

--- a/BottomSheetKit/Sources/BottomSheetKit/DefaultBottomSheet/DefaultBottomSheetAction.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/DefaultBottomSheet/DefaultBottomSheetAction.swift
@@ -14,13 +14,4 @@ class DefaultBottomSheetAction: BottomSheetAction {
   var completeAction: CompleteBottomSheetAction?
 
   init(view: DefaultBottomSheetView) { self.view = view }
-
-  func sendAction(_ action: DidBottomSheetActionType) {
-    completeAction?(action)
-  }
-
-
-  func cancel() {
-    completeAction?(.cancel)
-  }
 }

--- a/BottomSheetKit/Sources/BottomSheetKit/DefaultBottomSheet/DefaultBottomSheetViewController.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/DefaultBottomSheet/DefaultBottomSheetViewController.swift
@@ -23,7 +23,7 @@ internal final class DefaultBottomSheetViewController: UIViewController {
   }()
 
   private var bottomSheetView: DefaultBottomSheetView
-  private var action: BottomSheetAction
+    private var action: any BottomSheetAction
   private let disposeBag = DisposeBag()
   private var initialFrame: CGRect?
 

--- a/BottomSheetKit/Sources/BottomSheetKit/Model/BottomSheetModel.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/Model/BottomSheetModel.swift
@@ -19,5 +19,5 @@ public struct BottomSheetModel {
 public enum BottomSheetType {
   case defaultType
   case todoType(TodoModel)
-    case RuleType(PhotoCellModel)
+  case ruleType(PhotoCellModel)
 }

--- a/BottomSheetKit/Sources/BottomSheetKit/Model/BottomSheetModel.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/Model/BottomSheetModel.swift
@@ -19,4 +19,5 @@ public struct BottomSheetModel {
 public enum BottomSheetType {
   case defaultType
   case todoType(TodoModel)
+    case RuleType(PhotoCellModel)
 }

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/DataSource/RuleBottomDataSource.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/DataSource/RuleBottomDataSource.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  
+//
+//  Created by 김민재 on 2023/05/30.
+//
+
+import Foundation
+
+enum RuleBottomDataSource {
+    enum Section: Int, CaseIterable {
+        case photos
+    }
+
+    enum Item: Hashable {
+        case photos(_ model: RulePhoto)
+    }
+}

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/Model/PhotoCellModel.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/Model/PhotoCellModel.swift
@@ -10,13 +10,13 @@ import Foundation
 
 public struct PhotoCellModel {
     let title: String
-    let description: String
+    let description: String?
     let lastmodifedDate: String
     let photos: [RulePhoto]?
 
     public init(
         title: String,
-        description: String,
+        description: String?,
         lastmodifedDate: String,
         photos: [RulePhoto]?) {
         self.title = title

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/Model/PhotoCellModel.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/Model/PhotoCellModel.swift
@@ -1,0 +1,27 @@
+//
+//  File.swift
+//  
+//
+//  Created by 김민재 on 2023/05/31.
+//
+
+import Foundation
+
+
+public struct PhotoCellModel {
+    let title: String
+    let description: String
+    let lastmodifedDate: String
+    let photos: [RulePhoto]?
+
+    public init(
+        title: String,
+        description: String,
+        lastmodifedDate: String,
+        photos: [RulePhoto]?) {
+        self.title = title
+        self.description = description
+        self.lastmodifedDate = lastmodifedDate
+        self.photos = photos
+    }
+}

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/Model/RulePhoto.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/Model/RulePhoto.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  
+//
+//  Created by 김민재 on 2023/05/30.
+//
+
+import UIKit
+
+public struct RulePhoto: Hashable {
+    let image: UIImage
+
+    public init(image: UIImage) {
+        self.image = image
+    }
+}

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetAction.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetAction.swift
@@ -9,7 +9,8 @@ import Foundation
 
 final class RuleBottomSheetAction: BottomSheetAction {
 
-    let view: RuleBottomSheetView
+    var view: RuleBottomSheetView
+
     var completeAction: CompleteBottomSheetAction?
 
     init(view: RuleBottomSheetView) { self.view = view }

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetAction.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetAction.swift
@@ -15,7 +15,6 @@ final class RuleBottomSheetAction: BottomSheetAction {
     init(view: RuleBottomSheetView) { self.view = view }
 
     func sendAction(_ action: DidBottomSheetActionType) {
-        print(action)
         completeAction?(action)
     }
 

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetAction.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetAction.swift
@@ -1,0 +1,26 @@
+//
+//  File.swift
+//  
+//
+//  Created by 김민재 on 2023/05/30.
+//
+
+import Foundation
+
+final class RuleBottomSheetAction: BottomSheetAction {
+
+    let view: RuleBottomSheetView
+    var completeAction: CompleteBottomSheetAction?
+
+    init(view: RuleBottomSheetView) { self.view = view }
+
+    func sendAction(_ action: DidBottomSheetActionType) {
+        print(action)
+        completeAction?(action)
+    }
+
+    func cancel() {
+        completeAction?(.cancel)
+    }
+
+}

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetAction.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetAction.swift
@@ -14,13 +14,4 @@ final class RuleBottomSheetAction: BottomSheetAction {
     var completeAction: CompleteBottomSheetAction?
 
     init(view: RuleBottomSheetView) { self.view = view }
-
-    func sendAction(_ action: DidBottomSheetActionType) {
-        completeAction?(action)
-    }
-
-    func cancel() {
-        completeAction?(.cancel)
-    }
-
 }

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetView.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetView.swift
@@ -42,7 +42,9 @@ final class RuleBottomSheetView: UIView {
       return view
     }()
 
-    private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.createLayout())
+    private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.createLayout()).then {
+        $0.isScrollEnabled = false
+    }
 
     private let ruleTitleLabel: UILabel = {
         let label = UILabel()

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetView.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetView.swift
@@ -1,0 +1,318 @@
+//
+//  RuleBottomSheetView.swift
+//  
+//
+//  Created by 김민재 on 2023/05/30.
+//
+
+import UIKit
+import SnapKit
+import AssetKit
+
+
+final class RuleBottomSheetView: UIView {
+
+    private typealias SECTION = RuleBottomDataSource.Section
+    private typealias ITEM = RuleBottomDataSource.Item
+    private typealias DataSource = UICollectionViewDiffableDataSource<SECTION, ITEM>
+    private typealias SnapShot = NSDiffableDataSourceSnapshot<SECTION, ITEM>
+    private typealias CellReigstration = UICollectionView.CellRegistration
+
+    private enum Size {
+        static let leadingTrailingOffset: CGFloat = 70
+        static let stackViewVerticalSpacing: CGFloat = 16
+        static let stackViewLeadingTrailing: CGFloat = 24
+        static let handlerWidth: CGFloat = 80
+        static let handlerHeight: CGFloat = 5
+    }
+
+    private let rootView: UIView = {
+      let view = UIView()
+      view.layer.cornerRadius = 20
+        view.backgroundColor = Colors.white.color
+      view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+      return view
+    }()
+
+    private let handlerView: UIView = {
+      let view = UIView()
+      view.backgroundColor = Colors.g3.color
+      view.layer.cornerCurve = .continuous
+      view.layer.cornerRadius = 5
+      return view
+    }()
+
+    private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.createLayout())
+
+    private let ruleTitleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = Colors.black.color
+        label.font = Fonts.SpoqaHanSansNeo.bold.font(size: 20)
+        return label
+    }()
+
+    private let lastModifiedDateLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = Colors.g4.color
+        label.font = Fonts.Montserrat.medium.font(size: 12)
+        return label
+    }()
+
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = Colors.g6.color
+        label.font = Fonts.SpoqaHanSansNeo.medium.font(size: 14)
+        label.lineBreakMode = .byCharWrapping
+        label.lineBreakStrategy = .hangulWordPriority
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private let buttonStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+        stackView.spacing = Size.stackViewVerticalSpacing
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.layoutMargins = UIEdgeInsets(
+            top: 0,
+            left: Size.stackViewLeadingTrailing,
+            bottom: 0,
+            right: Size.stackViewLeadingTrailing)
+        return stackView
+    }()
+
+    lazy var modifyButton: UIButton = {
+      let button = UIButton()
+      button.setTitle("수정하기", for: .normal)
+      button.setTitleColor(Colors.black.color, for: .normal)
+        button.titleLabel?.font = Fonts.SpoqaHanSansNeo.medium.font(size: 14)
+      button.titleLabel?.textAlignment = .center
+      return button
+    }()
+
+    lazy var deleteButton: UIButton = {
+      let button = UIButton()
+      button.setTitle("삭제하기", for: .normal)
+      button.setTitleColor(Colors.red.color, for: .normal)
+        button.titleLabel?.font = Fonts.SpoqaHanSansNeo.medium.font(size: 14)
+      button.titleLabel?.textAlignment = .center
+      return button
+    }()
+
+    private var dataSource: DataSource?
+
+    init(model: PhotoCellModel) {
+        super.init(frame: .zero)
+        setLayout(photos: model.photos)
+        configViewLabel(model)
+        configureDataSource()
+        applySnapshot()
+        applyPhotoSnapshot(model.photos?.uniqued() ?? [])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateCollectionViewHeight()
+    }
+
+}
+
+private extension RuleBottomSheetView {
+
+    func configViewLabel(_ model: PhotoCellModel) {
+        self.lastModifiedDateLabel.text = model.lastmodifedDate
+        self.descriptionLabel.text = model.description
+        self.ruleTitleLabel.text = model.title
+    }
+
+
+    func setLayout(photos: [RulePhoto]?) {
+        self.addSubview(rootView)
+        [handlerView,
+         collectionView,
+         ruleTitleLabel,
+         lastModifiedDateLabel,
+         descriptionLabel,
+         buttonStackView].forEach {
+            rootView.addSubview($0)
+        }
+
+        rootView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+
+        handlerView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().inset(12)
+            make.width.equalTo(Size.handlerWidth)
+            make.height.equalTo(Size.handlerHeight)
+        }
+
+        collectionView.snp.makeConstraints { make in
+            make.top.equalTo(handlerView.snp.bottom).offset(32)
+            make.height.equalTo(230)
+            make.leading.trailing.equalToSuperview()
+        }
+
+        configCollectionViewLayout(photos: photos)
+
+        lastModifiedDateLabel.snp.makeConstraints { make in
+            make.leading.equalTo(ruleTitleLabel)
+            make.top.equalTo(ruleTitleLabel.snp.bottom).offset(12)
+        }
+
+        descriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(lastModifiedDateLabel.snp.bottom).offset(3)
+            make.leading.equalTo(ruleTitleLabel)
+            make.trailing.equalToSuperview().inset(24)
+        }
+
+        buttonStackView.snp.makeConstraints { make in
+            make.top.equalTo(descriptionLabel.snp.bottom).offset(36)
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalToSuperview().inset(26)
+        }
+
+        let line1 = makeG2LineView()
+        let line2 = makeG2LineView()
+
+        [modifyButton, deleteButton].forEach {
+            $0.snp.makeConstraints { make in
+                make.height.equalTo(26)
+            }
+        }
+
+        [line1, line2].forEach {
+            $0.snp.makeConstraints { make in
+                make.height.equalTo(1)
+            }
+        }
+
+        buttonStackView.addArrangedSubview(line1)
+        buttonStackView.addArrangedSubview(modifyButton)
+        buttonStackView.addArrangedSubview(line2)
+        buttonStackView.addArrangedSubview(deleteButton)
+    }
+
+    func configCollectionViewLayout(photos: [RulePhoto]?) {
+        if photos == nil {
+            collectionView.isHidden = true
+            ruleTitleLabel.snp.makeConstraints { make in
+                make.top.equalTo(handlerView.snp.bottom).offset(24)
+                make.leading.equalToSuperview().inset(24)
+            }
+            return
+        }
+        collectionView.isHidden = false
+        ruleTitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(collectionView.snp.bottom).offset(28)
+            make.leading.equalToSuperview().inset(24)
+        }
+    }
+
+    func createLayout() -> UICollectionViewLayout {
+        let sectionProvider = { [weak self] (
+          sectionIndex: Int,
+          layoutEnvironment: NSCollectionLayoutEnvironment
+        ) -> NSCollectionLayoutSection? in
+
+          guard
+            let self = self,
+            let sectionKind = RuleBottomDataSource.Section(rawValue: sectionIndex)
+          else {
+            return nil
+          }
+
+          let section: NSCollectionLayoutSection
+
+          switch sectionKind {
+          case .photos:
+            section = self.createPhotoSection()
+          }
+
+          return section
+        }
+
+        return UICollectionViewCompositionalLayout(sectionProvider: sectionProvider)
+    }
+
+    func createPhotoSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .fractionalWidth(1))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(226 / 375),
+            heightDimension: .fractionalWidth(226 / 375))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        group.interItemSpacing = .fixed(14)
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .continuous
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: Size.leadingTrailingOffset,
+            bottom: 0,
+            trailing: Size.leadingTrailingOffset)
+        return section
+    }
+
+    func makeG2LineView() -> UIView {
+        let view = UIView()
+        view.backgroundColor = Colors.g2.color
+        return view
+    }
+
+    func updateCollectionViewHeight() {
+        collectionView.layoutIfNeeded()
+        let height = collectionView.collectionViewLayout.collectionViewContentSize.height
+
+        collectionView.snp.updateConstraints { make in
+          make.height.equalTo(height)
+        }
+    }
+
+}
+
+
+private extension RuleBottomSheetView {
+
+    func applySnapshot() {
+        var snapshot = SnapShot()
+        let sections = SECTION.allCases
+        snapshot.appendSections(sections)
+        dataSource?.apply(snapshot, animatingDifferences: false)
+    }
+
+    func applyPhotoSnapshot(_ photos: [RulePhoto]) {
+        var snapshot = NSDiffableDataSourceSectionSnapshot<ITEM>()
+        let items = photos.map {
+            ITEM.photos($0)
+        }
+        snapshot.append(items)
+        dataSource?.apply(snapshot, to: .photos)
+    }
+
+    func configureDataSource() {
+        let photoCellRegistration = CellReigstration<PhotoCollectionViewCell, RulePhoto> { cell, _, model in
+            cell.configurePhotoCell(model)
+        }
+
+        self.dataSource = DataSource(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
+            switch itemIdentifier {
+            case .photos(let model):
+                return collectionView.dequeueConfiguredReusableCell(
+                    using: photoCellRegistration,
+                    for: indexPath,
+                    item: model)
+            }
+        })
+    }
+}

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetView.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetView.swift
@@ -129,8 +129,15 @@ private extension RuleBottomSheetView {
 
     func configViewLabel(_ model: PhotoCellModel) {
         self.lastModifiedDateLabel.text = model.lastmodifedDate
-        self.descriptionLabel.text = model.description
         self.ruleTitleLabel.text = model.title
+
+        if model.description == nil {
+            self.descriptionLabel.text = "설명 없음"
+            self.descriptionLabel.textColor = Colors.g4.color
+            return
+        }
+        self.descriptionLabel.text = model.description
+
     }
 
 

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetViewController.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetViewController.swift
@@ -1,0 +1,164 @@
+//
+//  RuleBottomSheetViewController.swift
+//  
+//
+//  Created by 김민재 on 2023/05/31.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+final class RuleBottomSheetViewController: UIViewController {
+
+    private let backgroundView: UIView = {
+      let view = UIView()
+      view.backgroundColor = .black.withAlphaComponent(0.5)
+      return view
+    }()
+
+    private let bottomSheetView: RuleBottomSheetView
+
+    private let action: RuleBottomSheetAction
+
+    private let disposeBag = DisposeBag()
+
+    init(action: RuleBottomSheetAction) {
+        self.action = action
+        self.bottomSheetView = action.view
+        super.init(nibName: nil, bundle: nil)
+
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setLayout()
+        setTapGesture()
+        setPanGesture()
+        bind()
+    }
+
+}
+
+// MARK: Gesture Animation Helper
+
+extension RuleBottomSheetViewController {
+    private func setTapGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+        backgroundView.addGestureRecognizer(tapGesture)
+    }
+
+    private func setPanGesture() {
+        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePan))
+        bottomSheetView.addGestureRecognizer(panGesture)
+    }
+
+    @objc
+    private func handleTap() {
+        sendDismissAction(.cancel)
+    }
+
+    @objc
+    private func handlePan(_ sender: UIPanGestureRecognizer) {
+        let viewTranslation = sender.translation(in: bottomSheetView)
+        switch sender.state {
+        case .changed:
+            if viewTranslation.y > 0 {
+                updateBottomSheetTop(self.bottomSheetView.frame.height - viewTranslation.y)
+                view.layoutIfNeeded()
+            }
+        case .ended:
+            if viewTranslation.y < bottomSheetView.frame.height / 2 {
+                self.updateBottomSheetTop(self.bottomSheetView.frame.height)
+                self.view.layoutIfNeeded()
+                break
+            }
+            sendDismissAction(.cancel)
+        default:
+            break
+        }
+
+    }
+
+    func showBottomSheetWithAnimation() {
+        self.updateBottomSheetTop(self.bottomSheetView.frame.height)
+        UIView.animate(withDuration: 0.5) {
+            self.backgroundView.alpha = 1
+            self.view.layoutIfNeeded()
+        }
+    }
+
+    private func hideBottomSheetWithAnimation() {
+        self.updateBottomSheetTop(0)
+        UIView.animate(withDuration: 0.5) {
+            self.view.layoutIfNeeded()
+            self.backgroundView.alpha = 0
+        } completion: { _ in
+            self.dismiss(animated: false)
+        }
+    }
+
+    private func sendDismissAction(_ action: DidBottomSheetActionType) {
+        hideBottomSheetWithAnimation()
+        switch action {
+        case .add:
+            break
+        case .modify:
+            self.action.sendAction(.modify)
+        case .delete:
+            self.action.sendAction(.delete)
+        case .cancel:
+            self.action.cancel()
+        }
+
+    }
+}
+
+
+
+// MARK: Layout
+
+extension RuleBottomSheetViewController {
+    private func setLayout() {
+        view.addSubview(backgroundView)
+        backgroundView.addSubview(bottomSheetView)
+
+        backgroundView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+
+        bottomSheetView.snp.makeConstraints { make in
+            make.top.equalTo(backgroundView.snp.bottom)
+            make.leading.trailing.equalToSuperview()
+        }
+    }
+
+    func updateBottomSheetTop(_ top: CGFloat) {
+        bottomSheetView.snp.updateConstraints { make in
+            make.top.equalTo(backgroundView.snp.bottom).inset(top)
+        }
+    }
+
+}
+
+extension RuleBottomSheetViewController {
+    private func bind() {
+        bottomSheetView.modifyButton.rx.tap
+          .asDriver(onErrorJustReturn: ())
+          .map { DidBottomSheetActionType.modify }
+          .drive(onNext: self.sendDismissAction)
+          .disposed(by: disposeBag)
+
+        bottomSheetView.deleteButton.rx.tap
+          .asDriver(onErrorJustReturn: ())
+          .map { DidBottomSheetActionType.delete }
+          .drive(onNext: self.sendDismissAction)
+          .disposed(by: disposeBag)
+    }
+
+}

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetViewController.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetViewController.swift
@@ -20,13 +20,14 @@ final class RuleBottomSheetViewController: UIViewController {
 
     private let bottomSheetView: RuleBottomSheetView
 
-    private let action: RuleBottomSheetAction
+    private let action: any BottomSheetAction
 
     private let disposeBag = DisposeBag()
 
-    init(action: RuleBottomSheetAction) {
+    init?(action: any BottomSheetAction) {
         self.action = action
-        self.bottomSheetView = action.view
+        guard let view = action.view as? RuleBottomSheetView else { return nil }
+        self.bottomSheetView = view
         super.init(nibName: nil, bundle: nil)
 
     }

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/SubViews/PhotoCollectionViewCell.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/SubViews/PhotoCollectionViewCell.swift
@@ -1,0 +1,40 @@
+//
+//  PhotoCollectionViewCell.swift
+//  
+//
+//  Created by 김민재 on 2023/05/30.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class PhotoCollectionViewCell: UICollectionViewCell {
+
+    private let imageView = UIImageView().then {
+        $0.layer.cornerRadius = 8
+        $0.clipsToBounds = true
+        $0.contentMode = .scaleToFill
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setLayout() {
+        contentView.addSubview(imageView)
+        imageView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+
+    func configurePhotoCell(_ model: RulePhoto) {
+        self.imageView.image = model.image
+    }
+    
+}

--- a/BottomSheetKit/Sources/BottomSheetKit/TodoBottomSheet/TodoBottomSheetAction.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/TodoBottomSheet/TodoBottomSheetAction.swift
@@ -13,12 +13,4 @@ class TodoBottomSheetAction: BottomSheetAction {
   var completeAction: CompleteBottomSheetAction?
 
   init(view: TodoBottomSheetView) { self.view = view }
-
-  func sendAction(_ action: DidBottomSheetActionType) {
-    completeAction?(action)
-  }
-
-  func cancel() {
-    completeAction?(.cancel)
-  }
 }

--- a/BottomSheetKit/Sources/BottomSheetKit/TodoBottomSheet/TodoBottomSheetAction.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/TodoBottomSheet/TodoBottomSheetAction.swift
@@ -9,8 +9,7 @@ import Foundation
 import UIKit
 
 class TodoBottomSheetAction: BottomSheetAction {
-
-  let view: TodoBottomSheetView
+  var view: TodoBottomSheetView
   var completeAction: CompleteBottomSheetAction?
 
   init(view: TodoBottomSheetView) { self.view = view }

--- a/BottomSheetKit/Sources/BottomSheetKit/TodoBottomSheet/TodoBottomSheetViewController.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/TodoBottomSheet/TodoBottomSheetViewController.swift
@@ -23,7 +23,7 @@ internal final class TodoBottomSheetViewController: UIViewController {
   }()
 
   private var bottomSheetView: TodoBottomSheetView
-  private var action: BottomSheetAction
+  private var action: any BottomSheetAction
   private let disposeBag = DisposeBag()
   private var initialFrame: CGRect?
 

--- a/Hous-iOS-release/Global/UIComponent/HousMenu.swift
+++ b/Hous-iOS-release/Global/UIComponent/HousMenu.swift
@@ -30,10 +30,12 @@ final class HousMenu: UIView {
     graySeperatorLine,
     guideButton
   ]).then {
-    $0.distribution = .equalSpacing
+    $0.distribution = .fill
     $0.alignment = .leading
     $0.axis = .vertical
-    $0.spacing = 8
+    $0.spacing = 5
+    $0.isLayoutMarginsRelativeArrangement = true
+    $0.layoutMargins = UIEdgeInsets(top: 14, left: 20, bottom: 14, right: 25)
   }
 
   override init(frame: CGRect) {
@@ -56,12 +58,13 @@ final class HousMenu: UIView {
 
   private func setLayout() {
     addSubview(stackView)
-    stackView.snp.makeConstraints { make in
-      make.edges.equalToSuperview().inset(14)
-    }
 
     graySeperatorLine.snp.makeConstraints { make in
       make.height.equalTo(1)
+    }
+
+    stackView.snp.makeConstraints { make in
+      make.edges.equalToSuperview()
     }
   }
 

--- a/Hous-iOS-release/Global/UIComponent/HousTextView.swift
+++ b/Hous-iOS-release/Global/UIComponent/HousTextView.swift
@@ -6,7 +6,7 @@
 //
 
 import UIKit
-
+import HousUIComponent
 import RxSwift
 
 final class HousTextView: UIView {
@@ -14,7 +14,7 @@ final class HousTextView: UIView {
   private let textView = UITextView()
   private let textCountLabel = HousLabel(
     text: "0/50",
-    font: Fonts.Montserrat.medium.font(size: 12), textColor: Colors.g5.color)
+    font: .EN2, textColor: Colors.g5.color)
 
   private let maxCount: Int
   private let disposeBag = DisposeBag()

--- a/Hous-iOS-release/Scene/OurRule/AddEdit/Cells/TitleDetailCollectionViewCell.swift
+++ b/Hous-iOS-release/Scene/OurRule/AddEdit/Cells/TitleDetailCollectionViewCell.swift
@@ -7,11 +7,13 @@
 
 import UIKit
 
+import HousUIComponent
+
 final class TitleDetailCollectionViewCell: UICollectionViewCell {
 
   private let titleLabel = HousLabel(
     text: StringLiterals.OurRule.AddEditView.titleText,
-    font: Fonts.SpoqaHanSansNeo.medium.font(size: 14),
+    font: .B2,
     textColor: Colors.black.color).then {
       $0.applyColor(to: "*", with: .red)
     }
@@ -20,7 +22,7 @@ final class TitleDetailCollectionViewCell: UICollectionViewCell {
 
   private let descriptionLabel = HousLabel(
     text: StringLiterals.OurRule.AddEditView.description,
-    font: Fonts.SpoqaHanSansNeo.medium.font(size: 14),
+    font: .B2,
     textColor: Colors.black.color
   )
 
@@ -36,7 +38,7 @@ final class TitleDetailCollectionViewCell: UICollectionViewCell {
   }
 
   private func setLayout() {
-    [titleLabel, textField, descriptionLabel, textView].forEach {
+    [titleLabel, descriptionLabel, textView].forEach {
       contentView.addSubview($0)
     }
     titleLabel.snp.makeConstraints { make in

--- a/Hous-iOS-release/Scene/OurRule/AddEdit/Views/HeaderCollectionReusableView.swift
+++ b/Hous-iOS-release/Scene/OurRule/AddEdit/Views/HeaderCollectionReusableView.swift
@@ -6,7 +6,7 @@
 //
 
 import UIKit
-
+import HousUIComponent
 import RxSwift
 
 final class HeaderCollectionReusableView: UICollectionReusableView {
@@ -17,7 +17,7 @@ final class HeaderCollectionReusableView: UICollectionReusableView {
 
   private let titleLabel = HousLabel(
     text: StringLiterals.OurRule.AddEditView.photo,
-    font: Fonts.SpoqaHanSansNeo.medium.font(size: 14),
+    font: .B2,
     textColor: Colors.black.color)
 
   private lazy var plusButton: UIButton = {

--- a/Hous-iOS-release/Scene/OurRule/MainRule/Model/HousRule.swift
+++ b/Hous-iOS-release/Scene/OurRule/MainRule/Model/HousRule.swift
@@ -5,11 +5,12 @@
 //  Created by 김민재 on 2023/05/13.
 //
 
-import Foundation
+import UIKit
 
 public struct HousRule: Hashable {
   let id: Int
   let name: String
+  let photos: [UIImage]? = nil
   let identifier = UUID()
 
   public func hash(into hasher: inout Hasher) {

--- a/Hous-iOS-release/Scene/OurRule/MainRule/RulesViewController.swift
+++ b/Hous-iOS-release/Scene/OurRule/MainRule/RulesViewController.swift
@@ -237,7 +237,7 @@ extension RulesViewController {
 private extension RulesViewController {
   func showBottomSheet(model: PhotoCellModel) {
 
-    let bottomSheetType = BottomSheetType.RuleType(model)
+    let bottomSheetType = BottomSheetType.ruleType(model)
 
     let ruleList = self.rules.map { $0.name }
 

--- a/Hous-iOS-release/Scene/TestScene/TestViewController.swift
+++ b/Hous-iOS-release/Scene/TestScene/TestViewController.swift
@@ -74,6 +74,24 @@ final class TestViewController: UIViewController {
     return button
   }()
 
+  private lazy var ruleBottomSheetButton: UIButton = {
+    let button = UIButton()
+    button.setTitle("RuleBottomSheetWithPhoto", for: .normal)
+    button.setTitleColor(UIColor.blue, for: .normal)
+    button.titleLabel?.font = .boldSystemFont(ofSize: 16)
+    button.addTarget(self, action: #selector(didTapButton8), for: .touchUpInside)
+    return button
+  }()
+
+  private lazy var ruleBottomSheetButton2: UIButton = {
+    let button = UIButton()
+    button.setTitle("RuleBottomSheetWithNoPhoto", for: .normal)
+    button.setTitleColor(UIColor.blue, for: .normal)
+    button.titleLabel?.font = .boldSystemFont(ofSize: 16)
+    button.addTarget(self, action: #selector(didTapButton9), for: .touchUpInside)
+    return button
+  }()
+
   init() {
     super.init(nibName: nil, bundle: nil)
     setupViews()
@@ -91,6 +109,8 @@ final class TestViewController: UIViewController {
     view.addSubview(duplicateButton)
     view.addSubview(defaultBottomSheetButton)
     view.addSubview(todoBottomSheetButton)
+    view.addSubView(ruleBottomSheetButton)
+    view.addSubview(ruleBottomSheetButton2)
 
     defaultButton.snp.makeConstraints { make in
       make.top.equalTo(self.view.safeAreaLayoutGuide.snp.top).inset(10)
@@ -127,7 +147,18 @@ final class TestViewController: UIViewController {
       make.height.equalTo(51)
       make.width.equalTo(300)
     }
+    ruleBottomSheetButton.snp.makeConstraints { make in
+      make.top.equalTo(self.todoBottomSheetButton.snp.bottom).offset(10)
+      make.height.equalTo(51)
+      make.width.equalTo(300)
+    }
+    ruleBottomSheetButton2.snp.makeConstraints { make in
+      make.top.equalTo(self.ruleBottomSheetButton.snp.bottom).offset(10)
+      make.height.equalTo(51)
+      make.width.equalTo(300)
+    }
   }
+
 }
 
 extension TestViewController {
@@ -280,6 +311,55 @@ extension TestViewController {
       }
     }
   }
+
+  @objc
+  private func didTapButton8() {
+
+    let model = PhotoCellModel(title: "바나나는 옷걸이에 걸어두기!",
+                               description: "옷걸이에 걸어두면 바나나는 자기가 아직도 나무에 걸려있다고 착각하고 싱싱한 상태를 유지한대..귀여워서 기절",
+                               lastmodifedDate: "마지막 수정 2023.04.01",
+                               photos: [RulePhoto(image: UIImage(systemName: "star.fill")!), RulePhoto(image: UIImage(systemName: "star")!)])
+    let model2 = PhotoCellModel(title: "바나나는 옷걸이에 걸어두기!",
+                               description: "옷걸이에 걸어두면 바나나는 자기가 아직도 나무에 걸려있다고 착각하고 싱싱한 상태를 유지한대..귀여워서 기절",
+                               lastmodifedDate: "마지막 수정 2023.04.01",
+                               photos: nil)
+    self.presentBottomSheet(.RuleType(model)) { actionType in
+      switch actionType {
+      case .add:
+        break
+      case .modify:
+        print("Modify")
+      case .delete:
+        print("Delete")
+      case .cancel:
+        print("Cancel")
+      }
+
+    }
+  }
+
+  @objc
+  private func didTapButton9() {
+
+    let model = PhotoCellModel(title: "바나나는 옷걸이에 걸어두기!",
+                               description: "옷걸이에 걸어두면 바나나는 자기가 아직도 나무에 걸려있다고 착각하고 싱싱한 상태를 유지한대..귀여워서 기절",
+                               lastmodifedDate: "마지막 수정 2023.04.01",
+                               photos: nil)
+    self.presentBottomSheet(.RuleType(model)) { actionType in
+      switch actionType {
+      case .add:
+        break
+      case .modify:
+        print("Modify")
+      case .delete:
+        print("Delete")
+      case .cancel:
+        print("Cancel")
+      }
+
+    }
+  }
+
 }
 
 extension TestViewController {

--- a/Hous-iOS-release/Scene/TestScene/TestViewController.swift
+++ b/Hous-iOS-release/Scene/TestScene/TestViewController.swift
@@ -79,7 +79,7 @@ final class TestViewController: UIViewController {
     button.setTitle("RuleBottomSheetWithPhoto", for: .normal)
     button.setTitleColor(UIColor.blue, for: .normal)
     button.titleLabel?.font = .boldSystemFont(ofSize: 16)
-//    button.addTarget(self, action: #selector(didTapButton8), for: .touchUpInside)
+    button.addTarget(self, action: #selector(didTapButton8), for: .touchUpInside)
     return button
   }()
 
@@ -322,6 +322,7 @@ extension TestViewController {
                                 .init(image: UIImage(systemName: "star.fill")!),
                                 .init(image: UIImage(systemName: "star")!)
                                ])
+
     self.presentBottomSheet(.ruleType(model)) { actionType in
       switch actionType {
       case .add:

--- a/Hous-iOS-release/Scene/TestScene/TestViewController.swift
+++ b/Hous-iOS-release/Scene/TestScene/TestViewController.swift
@@ -79,7 +79,7 @@ final class TestViewController: UIViewController {
     button.setTitle("RuleBottomSheetWithPhoto", for: .normal)
     button.setTitleColor(UIColor.blue, for: .normal)
     button.titleLabel?.font = .boldSystemFont(ofSize: 16)
-    button.addTarget(self, action: #selector(didTapButton8), for: .touchUpInside)
+//    button.addTarget(self, action: #selector(didTapButton8), for: .touchUpInside)
     return button
   }()
 
@@ -318,7 +318,10 @@ extension TestViewController {
     let model = PhotoCellModel(title: "바나나는 옷걸이에 걸어두기!",
                                description: "옷걸이에 걸어두면 바나나는 자기가 아직도 나무에 걸려있다고 착각하고 싱싱한 상태를 유지한대..귀여워서 기절",
                                lastmodifedDate: "마지막 수정 2023.04.01",
-                               photos: [RulePhoto(image: UIImage(systemName: "star.fill")!), RulePhoto(image: UIImage(systemName: "star")!)])
+                               photos: [
+                                .init(image: UIImage(systemName: "star.fill")!),
+                                .init(image: UIImage(systemName: "star")!)
+                               ])
     self.presentBottomSheet(.ruleType(model)) { actionType in
       switch actionType {
       case .add:

--- a/Hous-iOS-release/Scene/TestScene/TestViewController.swift
+++ b/Hous-iOS-release/Scene/TestScene/TestViewController.swift
@@ -319,7 +319,7 @@ extension TestViewController {
                                description: "옷걸이에 걸어두면 바나나는 자기가 아직도 나무에 걸려있다고 착각하고 싱싱한 상태를 유지한대..귀여워서 기절",
                                lastmodifedDate: "마지막 수정 2023.04.01",
                                photos: [RulePhoto(image: UIImage(systemName: "star.fill")!), RulePhoto(image: UIImage(systemName: "star")!)])
-    self.presentBottomSheet(.RuleType(model)) { actionType in
+    self.presentBottomSheet(.ruleType(model)) { actionType in
       switch actionType {
       case .add:
         break
@@ -341,7 +341,7 @@ extension TestViewController {
                                description: nil,
                                lastmodifedDate: "마지막 수정 2023.04.01",
                                photos: nil)
-    self.presentBottomSheet(.RuleType(model)) { actionType in
+    self.presentBottomSheet(.ruleType(model)) { actionType in
       switch actionType {
       case .add:
         break

--- a/Hous-iOS-release/Scene/TestScene/TestViewController.swift
+++ b/Hous-iOS-release/Scene/TestScene/TestViewController.swift
@@ -319,10 +319,6 @@ extension TestViewController {
                                description: "옷걸이에 걸어두면 바나나는 자기가 아직도 나무에 걸려있다고 착각하고 싱싱한 상태를 유지한대..귀여워서 기절",
                                lastmodifedDate: "마지막 수정 2023.04.01",
                                photos: [RulePhoto(image: UIImage(systemName: "star.fill")!), RulePhoto(image: UIImage(systemName: "star")!)])
-    let model2 = PhotoCellModel(title: "바나나는 옷걸이에 걸어두기!",
-                               description: "옷걸이에 걸어두면 바나나는 자기가 아직도 나무에 걸려있다고 착각하고 싱싱한 상태를 유지한대..귀여워서 기절",
-                               lastmodifedDate: "마지막 수정 2023.04.01",
-                               photos: nil)
     self.presentBottomSheet(.RuleType(model)) { actionType in
       switch actionType {
       case .add:
@@ -342,7 +338,7 @@ extension TestViewController {
   private func didTapButton9() {
 
     let model = PhotoCellModel(title: "바나나는 옷걸이에 걸어두기!",
-                               description: "옷걸이에 걸어두면 바나나는 자기가 아직도 나무에 걸려있다고 착각하고 싱싱한 상태를 유지한대..귀여워서 기절",
+                               description: nil,
                                lastmodifedDate: "마지막 수정 2023.04.01",
                                photos: nil)
     self.presentBottomSheet(.RuleType(model)) { actionType in

--- a/HousUIComponent/Sources/HousUIComponent/ScreenUtils.swift
+++ b/HousUIComponent/Sources/HousUIComponent/ScreenUtils.swift
@@ -1,0 +1,22 @@
+//
+//  ScreenUtils.swift
+//  
+//
+//  Created by 김민재 on 2023/06/18.
+//
+
+import UIKit
+
+final class ScreenUtils {
+    static func getWidth(_ value: CGFloat) -> CGFloat {
+        let width = UIScreen.main.bounds.width
+        let standardWidth: CGFloat = 375.0
+        return width / standardWidth * value
+    }
+
+    static func getHeight(_ value: CGFloat) -> CGFloat {
+        let height = UIScreen.main.bounds.height
+        let standardheight: CGFloat = 812.0
+        return height / standardheight * value
+    }
+}

--- a/HousUIComponent/Sources/HousUIComponent/TextField/FilledHousTextField.swift
+++ b/HousUIComponent/Sources/HousUIComponent/TextField/FilledHousTextField.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import AssetKit
 
-final class FilledHousTextField: UITextField {
+public final class FilledHousTextField: UITextField {
 
   private let maxCount: Int
 
@@ -21,7 +21,7 @@ final class FilledHousTextField: UITextField {
     textColor: Colors.g5.color
   )
 
-  init(maxCount: Int) {
+  public init(maxCount: Int) {
     self.maxCount = maxCount
     super.init(frame: .zero)
     setLayout()


### PR DESCRIPTION
## [#195] FEAT : Rule바텀시트 구현

## 🌱 작업한 내용

- Rule바텀시트(사진있는경우)
- Rule바텀시트(사진있는경우)
- 설명이 없는 경우에는 '설명없음'
- 아직 Rule관련 API는 그대로인 것 같아 TODO 주석으로 남겨놓았습니다 (언제나오냐에 따라 제가 하거나 아마 의진형한테 부탁할 수도 있을듯??)

## 🌱 PR Point
- protocol에 view를 추가하여 action의 구체화된 클래스 타입을 넘기는 것이 아닌 프로토콜을 넘기게끔 개선했습니다.
### 남는 궁금한점
- init에서 downcasting이 최선일지
- any대신에 다른 방법도 있는지

개선과정을 정리한 링크 첨부합니다(https://codingmon.tistory.com/53)

++ 20230606
protocol 기본 구현을 추가해서 중복코드를 줄였습니다. (sendAction, cancel)

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| RuleBottomSheet | ![Simulator Screen Recording - iPhone 13 mini - 2023-06-01 at 01 47 09](https://github.com/Hous-Release/hous-iOS/assets/60292150/939f414d-0369-49e6-b973-79a50f1a6da9) |

## 📮 관련 이슈

- Resolved: #195 
