### PR TITLE
Setting: Kakao Dev key 추가

### DIFF
--- a/Hous-iOS-release.xcodeproj/project.pbxproj
+++ b/Hous-iOS-release.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		773F1E8F28D5944800AE7521 /* Network in Frameworks */ = {isa = PBXBuildFile; productRef = 773F1E8E28D5944800AE7521 /* Network */; };
 		7757A3E228E734E20068B13C /* SplashReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7757A3E128E734E20068B13C /* SplashReactor.swift */; };
 		7757A3E428E737520068B13C /* HouseErrorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7757A3E328E737520068B13C /* HouseErrorModel.swift */; };
+		7757F2A62A4AFFC700823F04 /* KakaoSecretKeyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7757F2A52A4AFFC700823F04 /* KakaoSecretKeyTest.swift */; };
 		777085AC29040D5C0018240B /* AssetKit in Frameworks */ = {isa = PBXBuildFile; productRef = 777085AB29040D5C0018240B /* AssetKit */; };
 		777085B029040DE00018240B /* TestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777085AF29040DE00018240B /* TestViewController.swift */; };
 		777C666128A74A62000BECEA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777C666028A74A62000BECEA /* AppDelegate.swift */; };
@@ -351,9 +352,10 @@
 		773BABC129D17B4B00ABAACD /* Hous_iOS_releaseUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hous_iOS_releaseUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		7757A3E128E734E20068B13C /* SplashReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashReactor.swift; sourceTree = "<group>"; };
 		7757A3E328E737520068B13C /* HouseErrorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseErrorModel.swift; sourceTree = "<group>"; };
+		7757F2A52A4AFFC700823F04 /* KakaoSecretKeyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoSecretKeyTest.swift; sourceTree = "<group>"; };
 		777085A82903F1980018240B /* AssetKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = AssetKit; sourceTree = "<group>"; };
 		777085AF29040DE00018240B /* TestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestViewController.swift; sourceTree = "<group>"; };
-		777C665D28A74A62000BECEA /* Hous-iOS-release.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Hous-iOS-release.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		777C665D28A74A62000BECEA /* Hous-(Dev).app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Hous-(Dev).app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		777C666028A74A62000BECEA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		777C666228A74A62000BECEA /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		777C666928A74A63000BECEA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -711,6 +713,7 @@
 		7725815729D2B24900E9FC0E /* Hous-iOS-releaseTests */ = {
 			isa = PBXGroup;
 			children = (
+				7757F2A22A4AFF8C00823F04 /* SettingTests */,
 				7725815829D2B24900E9FC0E /* Hous_iOS_releaseTests.swift */,
 			);
 			path = "Hous-iOS-releaseTests";
@@ -737,6 +740,14 @@
 				773BABC129D17B4B00ABAACD /* Hous_iOS_releaseUITestsLaunchTests.swift */,
 			);
 			path = "Hous-iOS-releaseUITests";
+			sourceTree = "<group>";
+		};
+		7757F2A22A4AFF8C00823F04 /* SettingTests */ = {
+			isa = PBXGroup;
+			children = (
+				7757F2A52A4AFFC700823F04 /* KakaoSecretKeyTest.swift */,
+			);
+			path = SettingTests;
 			sourceTree = "<group>";
 		};
 		777085AD29040DC50018240B /* TestScene */ = {
@@ -771,7 +782,7 @@
 		777C665E28A74A62000BECEA /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				777C665D28A74A62000BECEA /* Hous-iOS-release.app */,
+				777C665D28A74A62000BECEA /* Hous-(Dev).app */,
 				773BABBD29D17B4B00ABAACD /* Hous-iOS-releaseUITests.xctest */,
 				7725815629D2B24900E9FC0E /* Hous-iOS-releaseTests.xctest */,
 			);
@@ -1785,7 +1796,7 @@
 				B84AC0282A1A5EA7003F1CA5 /* HousUIComponent */,
 			);
 			productName = "Hous-iOS-release";
-			productReference = 777C665D28A74A62000BECEA /* Hous-iOS-release.app */;
+			productReference = 777C665D28A74A62000BECEA /* Hous-(Dev).app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -1929,6 +1940,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7725815929D2B24900E9FC0E /* Hous_iOS_releaseTests.swift in Sources */,
+				7757F2A62A4AFFC700823F04 /* KakaoSecretKeyTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Hous-iOS-release/Scene/Profile/BadgeViewModel.swift
+++ b/Hous-iOS-release/Scene/Profile/BadgeViewModel.swift
@@ -151,27 +151,11 @@ struct RoomBadgeViewModel {
   let isAcquired: Bool
   let isRepresenting: Bool
   var tapState: BadgeViewTapState
-
-  init(id: Int, imageURL: String, title: String, description: String,
-       isAcquired: Bool, isRepresenting: Bool, tapState: BadgeViewTapState) {
-    self.id = id
-    self.imageURL = imageURL
-    self.title = title
-    self.description = description
-    self.isAcquired = isAcquired
-    self.isRepresenting = isRepresenting
-    self.tapState = tapState
-  }
 }
 
 struct RepresentingBadgeViewModel {
   let imageURL: String
   var title: String
-
-  init(imageURL: String, title: String) {
-    self.imageURL = imageURL
-    self.title = title
-  }
 }
 
 enum BadgeViewTapState {

--- a/Hous-iOS-release/Scene/SignIn/SignInViewController.swift
+++ b/Hous-iOS-release/Scene/SignIn/SignInViewController.swift
@@ -292,7 +292,9 @@ extension SignInViewController {
 
   private func configureKakaoSignIn() {
 
-    kakaoLoginManager.configure(appKey: "23a6d7ad94f44f0e474ee41b4e6d9fab")
+    guard let key = Bundle.main.infoDictionary?["KAKAO_AUTH_KEY"] as? String else { return }
+
+    kakaoLoginManager.configure(appKey: key)
 
     kakaoLoginManager.onSuccess = { [weak self] identifyToken, _ in
       self?.signInRelay.accept((identifyToken, nil))

--- a/Hous-iOS-release/Setting/Info.plist
+++ b/Hous-iOS-release/Setting/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>KAKAO_AUTH_KEY</key>
+	<string>$(KAKAO_AUTH_KEY)</string>
 	<key>APP_BUNDLE_ID</key>
 	<string>$(APP_BUNDLE_ID)</string>
 	<key>MARKETING_VERSION</key>
@@ -17,7 +19,7 @@
 			<string>kakaosignin</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>kakao23a6d7ad94f44f0e474ee41b4e6d9fab</string>
+				<string>kakao$(KAKAO_AUTH_KEY)</string>
 			</array>
 		</dict>
 	</array>

--- a/Hous-iOS-releaseTests/SettingTests/KakaoSecretKeyTest.swift
+++ b/Hous-iOS-releaseTests/SettingTests/KakaoSecretKeyTest.swift
@@ -1,0 +1,56 @@
+//
+//  KakaoSecretKeyTest.swift
+//  Hous-iOS-releaseTests
+//
+//  Created by 김호세 on 2023/06/27.
+//
+
+import Foundation
+import XCTest
+@testable import Hous_iOS_release
+
+final class KakaoSecretKeyTest: XCTestCase {
+
+  override func setUpWithError() throws {
+  }
+
+  override func tearDownWithError() throws {
+  }
+
+  func testPrintSecretKEYByConfig() {
+    guard let key = Bundle.main.infoDictionary?["KAKAO_AUTH_KEY"] as? String else { return }
+    print("KAKAO_AUTH_KEY ==", key)
+  }
+
+  func testPrintSecretURLSchemesByConfig() {
+    print("KAKAO_URL_SCHEMES ==", Bundle.kakaoURLSchemes)
+  }
+}
+
+// MARK: For Test extension
+fileprivate extension Bundle {
+
+  static let kakaoURLSchemes: String = {
+
+    var result = ""
+
+    guard
+      let urlTypes = main.infoDictionary?["CFBundleURLTypes"] as? [[String: Any]]
+    else {
+      return ""
+    }
+    for urlTypeDictionary in urlTypes {
+      guard
+        let identifier = urlTypeDictionary["CFBundleURLName"] as? String,
+        identifier == "kakaosignin",
+        let urlSchemes = urlTypeDictionary["CFBundleURLSchemes"] as? [String],
+        let kakaoURLScheme = urlSchemes.first
+
+      else {
+        continue
+      }
+      result = kakaoURLScheme
+    }
+    return result
+  }()
+}


### PR DESCRIPTION
## [#186] 카카오로그인 Dev Key 추가

바뀐 xcconfig 파일은 Slack에서 확인하고 다운로드 하세요.
이 코드가 Dev에 위 폴더를 Path: Setting/Configuration 을 바꿔주세요.

## 🌱 작업한 내용

- xcconfig 파일에 KAKAO_AUTH_KEY 추가
- Info.plist에 KAKAO_AUTH_KEY 추가
- kakao 로그인 시 appKey를 전달인자 넘겨줄 때 info.plist에서 값 가져와서 넘겨주는 코드 추가
- 환경에 따른 Kakao key 값 테스트 코드 작성

## 🌱 PR Point

- Info.plish에서 값 꺼내는 법: xcconfig -> info.plist -> 값 꺼내기

