### PR TITLE
[#213] FEAT: 규칙 플로우에서 필요한 API 연결

### DIFF
--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/Model/PhotoCellModel.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/Model/PhotoCellModel.swift
@@ -9,10 +9,10 @@ import Foundation
 
 
 public struct PhotoCellModel {
-    let title: String
-    let description: String?
-    let lastmodifedDate: String
-    let photos: [RulePhoto]?
+    public let title: String
+    public let description: String?
+    public let lastmodifedDate: String
+    public let photos: [RulePhoto]?
 
     public init(
         title: String,

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/Model/PhotoCellModel.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/Model/PhotoCellModel.swift
@@ -9,19 +9,22 @@ import Foundation
 
 
 public struct PhotoCellModel {
+    public let ruleId: Int?
     public let title: String
     public let description: String?
     public let lastmodifedDate: String
     public let photos: [RulePhoto]?
 
     public init(
+        ruleId: Int? = nil,
         title: String,
         description: String?,
         lastmodifedDate: String,
         photos: [RulePhoto]?) {
-        self.title = title
-        self.description = description
-        self.lastmodifedDate = lastmodifedDate
-        self.photos = photos
-    }
+            self.ruleId = ruleId
+            self.title = title
+            self.description = description
+            self.lastmodifedDate = lastmodifedDate
+            self.photos = photos
+        }
 }

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/Model/RulePhoto.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/Model/RulePhoto.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 public struct RulePhoto: Hashable {
-    let image: String
+    public let image: String
 
     public init(image: String) {
         self.image = image

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/Model/RulePhoto.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/Model/RulePhoto.swift
@@ -8,9 +8,9 @@
 import UIKit
 
 public struct RulePhoto: Hashable {
-    let image: UIImage
+    let image: String
 
-    public init(image: UIImage) {
+    public init(image: String) {
         self.image = image
     }
 }

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetView.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/RuleBottomSheetView.swift
@@ -128,7 +128,15 @@ final class RuleBottomSheetView: UIView {
 private extension RuleBottomSheetView {
 
     func configViewLabel(_ model: PhotoCellModel) {
-        self.lastModifiedDateLabel.text = model.lastmodifedDate
+        let inputDateFormatter = DateFormatter()
+        inputDateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
+        if let date = inputDateFormatter.date(from: model.lastmodifedDate) {
+            let myFormatter = DateFormatter()
+            myFormatter.dateFormat = "yyyy.MM.dd"
+            let str = myFormatter.string(from: date)
+            self.lastModifiedDateLabel.text = "마지막 수정 \(str)"
+        }
+
         self.ruleTitleLabel.text = model.title
 
         if model.description == nil {
@@ -261,7 +269,7 @@ private extension RuleBottomSheetView {
             widthDimension: .fractionalWidth(226 / 375),
             heightDimension: .fractionalWidth(226 / 375))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-        group.interItemSpacing = .fixed(14)
+        group.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 14)
 
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .continuous

--- a/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/SubViews/PhotoCollectionViewCell.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/RuleBottomSheet/SubViews/PhotoCollectionViewCell.swift
@@ -8,6 +8,7 @@
 import UIKit
 import SnapKit
 import Then
+import Kingfisher
 
 final class PhotoCollectionViewCell: UICollectionViewCell {
 
@@ -34,7 +35,8 @@ final class PhotoCollectionViewCell: UICollectionViewCell {
     }
 
     func configurePhotoCell(_ model: RulePhoto) {
-        self.imageView.image = model.image
+        guard let url = URL(string: model.image) else { return }
+        self.imageView.kf.setImage(with: url)
     }
     
 }

--- a/Hous-iOS-release.xcodeproj/project.pbxproj
+++ b/Hous-iOS-release.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		9BF9AD71291EB377006A0BDE /* ProfileEditTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF9AD70291EB377006A0BDE /* ProfileEditTextView.swift */; };
 		9BF9AD74291FBA62006A0BDE /* ProfileTestCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF9AD73291FBA62006A0BDE /* ProfileTestCollectionViewCell.swift */; };
 		9BF9AD76291FC804006A0BDE /* ProfileTestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF9AD75291FC804006A0BDE /* ProfileTestModel.swift */; };
+		B50DD01F2A9394100054B357 /* AddEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50DD01E2A9394100054B357 /* AddEditViewModel.swift */; };
 		B51383152A15FD3B00167728 /* AddEditRuleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51383142A15FD3B00167728 /* AddEditRuleViewController.swift */; };
 		B5265D8D2A0EAF440097D147 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5265D8C2A0EAF440097D147 /* Constant.swift */; };
 		B5265D912A0EB48C0097D147 /* RulesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5265D902A0EB48C0097D147 /* RulesViewController.swift */; };
@@ -473,6 +474,7 @@
 		9BF9AD73291FBA62006A0BDE /* ProfileTestCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTestCollectionViewCell.swift; sourceTree = "<group>"; };
 		9BF9AD75291FC804006A0BDE /* ProfileTestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTestModel.swift; sourceTree = "<group>"; };
 		9BF9AD7729201812006A0BDE /* ProfileTestInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTestInfoViewController.swift; sourceTree = "<group>"; };
+		B50DD01E2A9394100054B357 /* AddEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditViewModel.swift; sourceTree = "<group>"; };
 		B51383142A15FD3B00167728 /* AddEditRuleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditRuleViewController.swift; sourceTree = "<group>"; };
 		B5265D8C2A0EAF440097D147 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		B5265D902A0EB48C0097D147 /* RulesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesViewController.swift; sourceTree = "<group>"; };
@@ -1154,6 +1156,7 @@
 				B5D06E442A19E38900048C72 /* Views */,
 				B51383142A15FD3B00167728 /* AddEditRuleViewController.swift */,
 				B5D06E4E2A19EF5600048C72 /* AddEditRuleDataSource.swift */,
+				B50DD01E2A9394100054B357 /* AddEditViewModel.swift */,
 			);
 			path = AddEdit;
 			sourceTree = "<group>";
@@ -2135,6 +2138,7 @@
 				B856702328C9C76300B49984 /* UnderlinedTextField.swift in Sources */,
 				B8555ABF291CBB4E00E943AE /* DaysOfWeekCollectionViewCell.swift in Sources */,
 				9B9E999C293CE3C400537785 /* ProfileSettingModel.swift in Sources */,
+				B50DD01F2A9394100054B357 /* AddEditViewModel.swift in Sources */,
 				B856702F28CA93F600B49984 /* UILabel+Extension.swift in Sources */,
 				B84EA6E128DD914F00C92FCD /* PagingViewReactor.swift in Sources */,
 				B8B8A89828DF9196009FD784 /* EnterRoomViewController.swift in Sources */,

--- a/Hous-iOS-release.xcodeproj/project.pbxproj
+++ b/Hous-iOS-release.xcodeproj/project.pbxproj
@@ -155,7 +155,6 @@
 		B54D39F62914197700DA3A95 /* AddRuleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D39F52914197700DA3A95 /* AddRuleViewController.swift */; };
 		B54D39F829141DC200DA3A95 /* AddRuleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D39F729141DC200DA3A95 /* AddRuleViewModel.swift */; };
 		B54D39FC29153C6E00DA3A95 /* DeleteRuleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D39FB29153C6E00DA3A95 /* DeleteRuleViewController.swift */; };
-		B54D39FE29153C7700DA3A95 /* DeleteRuleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D39FD29153C7700DA3A95 /* DeleteRuleViewModel.swift */; };
 		B54D3A002919634A00DA3A95 /* BadgeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D39FF2919634A00DA3A95 /* BadgeViewController.swift */; };
 		B54D3A022919707100DA3A95 /* RepresentingBadgeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D3A012919707100DA3A95 /* RepresentingBadgeCollectionViewCell.swift */; };
 		B54D3A042919708400DA3A95 /* BadgeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D3A032919708400DA3A95 /* BadgeCollectionViewCell.swift */; };
@@ -167,6 +166,7 @@
 		B591485C290AB69300618F26 /* RulesTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B591485B290AB69300618F26 /* RulesTableViewCell.swift */; };
 		B5914885290BC2D200618F26 /* RulesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5914884290BC2D200618F26 /* RulesViewModel.swift */; };
 		B591488C290D21A700618F26 /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = B591488B290D21A700618F26 /* UIViewController+Rx.swift */; };
+		B59480F62A9DE804007971A8 /* DeleteRuleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D39FD29153C7700DA3A95 /* DeleteRuleViewModel.swift */; };
 		B595000528D5B74700F6B2E4 /* EditHousNameDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B595000428D5B74700F6B2E4 /* EditHousNameDTO.swift */; };
 		B595000928D6629700F6B2E4 /* QuitPopUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B595000828D6629700F6B2E4 /* QuitPopUpViewController.swift */; };
 		B595FFB428C9B2CA00F6B2E4 /* MainHomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B595FFB328C9B2CA00F6B2E4 /* MainHomeViewModel.swift */; };
@@ -2171,7 +2171,6 @@
 				B595FFDC28CDBEEF00F6B2E4 /* MainHomeRulesCollectionViewCell.swift in Sources */,
 				B8DA060228E541FC00C79B40 /* EnterRoomCodeViewReactor.swift in Sources */,
 				B8D066DE28FA95BB00A99907 /* MemberCollectionViewCell.swift in Sources */,
-				B54D39FE29153C7700DA3A95 /* DeleteRuleViewModel.swift in Sources */,
 				9BDBAD7629240C3C0096FE38 /* MateProfileViewModel.swift in Sources */,
 				B8D8A4B22A1CAFA8005A8258 /* SearchBarViewController.swift in Sources */,
 				770D770429B86B05002E60A2 /* ProfileTestInfoViewController.swift in Sources */,
@@ -2210,6 +2209,7 @@
 				770B959B28F15E5200C8C945 /* AlertService.swift in Sources */,
 				B8DA060828E5A09300C79B40 /* ProgressBubbleView.swift in Sources */,
 				B856701428C8E56600B49984 /* CALayer+Extension.swift in Sources */,
+				B59480F62A9DE804007971A8 /* DeleteRuleViewModel.swift in Sources */,
 				B856702128C9AA3600B49984 /* EnterInfoView.swift in Sources */,
 				B8B56BA328E2E76800FC99DA /* EnterRoomCodeViewController.swift in Sources */,
 				B53F0FBE29102886004F1872 /* EditRuleTableViewCell.swift in Sources */,

--- a/Hous-iOS-release/Global/UIComponent/HousTextView.swift
+++ b/Hous-iOS-release/Global/UIComponent/HousTextView.swift
@@ -11,7 +11,7 @@ import RxSwift
 
 final class HousTextView: UIView {
 
-  private let textView = UITextView()
+  public let textView = UITextView()
   private let textCountLabel = HousLabel(
     text: "0/50",
     font: .EN2, textColor: Colors.g5.color)

--- a/Hous-iOS-release/Repository/Rule/RuleRespository.swift
+++ b/Hous-iOS-release/Repository/Rule/RuleRespository.swift
@@ -13,6 +13,7 @@ import RxSwift
 import RxCocoa
 
 public enum RuleRepositoryEvent {
+  case getRuleDetail(RuleDTO.Response.SingleRuleResponseDTO)
   case getRules([HousRule])
   case sendError(HouseErrorModel?)
 }
@@ -21,6 +22,7 @@ public protocol RuleRepository {
   var event: PublishSubject<RuleRepositoryEvent> { get }
 
   func getRules()
+  func getRuleDetail(ruleId: Int)
 }
 
 public final class RuleRepositoryImp: BaseService, RuleRepository {
@@ -36,6 +38,18 @@ public final class RuleRepositoryImp: BaseService, RuleRepository {
           return HousRule(id: $0.id, name: $0.name)
         }
         self.event.onNext(.getRules(housRules))
+      }
+      .disposed(by: disposeBag)
+  }
+
+  public func getRuleDetail(ruleId: Int) {
+    NetworkService.shared.ruleRepository.getRuleDetail(ruleId: ruleId)
+      .subscribe { ruleDetailDTO in
+        guard let dto = ruleDetailDTO.element,
+              let model = dto
+        else { return }
+
+        self.event.onNext(.getRuleDetail(model))
       }
       .disposed(by: disposeBag)
   }

--- a/Hous-iOS-release/Repository/Rule/RuleRespository.swift
+++ b/Hous-iOS-release/Repository/Rule/RuleRespository.swift
@@ -15,6 +15,7 @@ import RxCocoa
 public enum RuleRepositoryEvent {
   case getRuleDetail(RuleDTO.Response.SingleRuleResponseDTO)
   case getRules([HousRule])
+  case deleteRule(Int?)
   case sendError(HouseErrorModel?)
 }
 
@@ -23,12 +24,23 @@ public protocol RuleRepository {
 
   func getRules()
   func getRuleDetail(ruleId: Int)
+  func deleteRule(ruleId: Int)
 }
 
 public final class RuleRepositoryImp: BaseService, RuleRepository {
+
   public var event = PublishSubject<RuleRepositoryEvent>()
 
   private let disposeBag = DisposeBag()
+
+  public func deleteRule(ruleId: Int) {
+    NetworkService.shared.ruleRepository.deleteRule(ruleId: ruleId)
+      .subscribe(onNext: { [weak self] ruleId in
+        guard let self else { return }
+        self.event.onNext(.deleteRule(ruleId))
+      })
+      .disposed(by: disposeBag)
+  }
 
   public func getRules() {
     NetworkService.shared.ruleRepository.getRulesName()

--- a/Hous-iOS-release/Scene/OurRule/AddEdit/AddEditRuleViewController.swift
+++ b/Hous-iOS-release/Scene/OurRule/AddEdit/AddEditRuleViewController.swift
@@ -151,15 +151,6 @@ final class AddEditRuleViewController: BaseViewController, LoadingPresentable {
         })
         else { return }
 
-        // TODO: - 규칙 수정 API
-        /*
-         1. ruleId와 PhotoCellModel를 이쪽 VC로 넘어올 때 받아온다. <- 메서드? 변수에 넣어주기?
-         2. PhotoCellModel에서 받아온 정보로 View에 데이터 넣어주기 <- 이건 이 VC present해주는 RulesViewController쪽에서 메서드 호출.
-         3. 그리고 뷰가 보여지고 수정할 거 하고 '저장' 버튼을 누르면 담고 있던 RuleId과 model을 viewModel로 넘긴다.
-         4. viewModel에서 넘겨받은 ruleId와 이미지 등등을 이용해서 규칙 수정 API 호출하기
-         5. API 호출 후 성공이면 pop
-         */
-
         var model = CreateRuleRequestDTO(name: self.ruleTitle, description: self.ruleDescription, images: images)
         if type == .updateRule {
           model.ruleId = photoCellModel?.ruleId
@@ -176,18 +167,6 @@ final class AddEditRuleViewController: BaseViewController, LoadingPresentable {
         self.navigationController?.popViewController(animated: true)
       })
       .disposed(by: disposeBag)
-
-//    let input = AddRuleViewModel.Input(
-    //      navBackButtonDidTapped: navigationBar.backButton.rx.tap.asObservable(),
-    //      viewDidTapped: view.rx.tapGesture().asObservable(),
-    //      saveButtonDidTapped: newRulesSubject
-    //        .do(onNext: { [weak self] _ in self?.showLoading() }),
-    //      plusButtonDidTapped: plusButton.rx.tap.asObservable(),
-    //      textFieldEdit: ruleTextField.rx.text
-    //        .orEmpty
-    //        .distinctUntilChanged()
-    //        .asObservable()
-    //    )
   }
 
 }
@@ -420,13 +399,6 @@ extension AddEditRuleViewController: PHPickerViewControllerDelegate {
     }
 
     picker.dismiss(animated: true)
-
-//    albumImageUploadedSubject
-//      .asDriver(onErrorJustReturn: ())
-//      .drive(onNext: {
-//        picker.dismiss(animated: true)
-//      })
-//      .disposed(by: disposeBag)
   }
 
 }

--- a/Hous-iOS-release/Scene/OurRule/AddEdit/AddEditViewModel.swift
+++ b/Hous-iOS-release/Scene/OurRule/AddEdit/AddEditViewModel.swift
@@ -1,0 +1,39 @@
+//
+//  AddEditViewModel.swift
+//  Hous-iOS-release
+//
+//  Created by 김민재 on 2023/08/21.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+import Network
+
+final class AddEditViewModel {
+
+  // MARK: - Inputs
+  struct Input {
+    let addButtonDidTap: Observable<CreateRuleRequestDTO>
+  }
+
+  struct Output {
+    let createdRule: Driver<Int>
+  }
+
+  func transform(_ input: Input) -> Output {
+    let savedCompleted = input.addButtonDidTap
+      .flatMap { dto in
+        return NetworkService.shared.ruleRepository.createRules(.init(name: dto.name, description: dto.description), images: dto.images)
+      }
+      .asDriver(onErrorJustReturn: 400)
+    //      .flatMap { ruleNames -> Observable<Int> in
+    //        return NetworkService.shared.ruleRepository.createRules(
+    //          RuleDTO.Request.createRuleRequestDTO(ruleNames: ruleNames)
+    //        )
+    //      }
+    //      .asDriver(onErrorJustReturn: 400)
+    return Output(createdRule: savedCompleted)
+  }
+
+}

--- a/Hous-iOS-release/Scene/OurRule/AddEdit/AddEditViewModel.swift
+++ b/Hous-iOS-release/Scene/OurRule/AddEdit/AddEditViewModel.swift
@@ -24,7 +24,13 @@ final class AddEditViewModel {
   func transform(_ input: Input) -> Output {
     let savedCompleted = input.addButtonDidTap
       .flatMap { dto in
-        return NetworkService.shared.ruleRepository.createRules(.init(name: dto.name, description: dto.description), images: dto.images)
+        if let ruleId = dto.ruleId {
+          return NetworkService.shared.ruleRepository
+            .updateRule(.init(name: dto.name, description: dto.description), ruleId: ruleId, images: dto.images)
+        }
+
+        return NetworkService.shared.ruleRepository
+          .createRules(.init(name: dto.name, description: dto.description), images: dto.images)
       }
       .asDriver(onErrorJustReturn: 400)
     //      .flatMap { ruleNames -> Observable<Int> in

--- a/Hous-iOS-release/Scene/OurRule/AddEdit/AddEditViewModel.swift
+++ b/Hous-iOS-release/Scene/OurRule/AddEdit/AddEditViewModel.swift
@@ -33,12 +33,7 @@ final class AddEditViewModel {
           .createRules(.init(name: dto.name, description: dto.description), images: dto.images)
       }
       .asDriver(onErrorJustReturn: 400)
-    //      .flatMap { ruleNames -> Observable<Int> in
-    //        return NetworkService.shared.ruleRepository.createRules(
-    //          RuleDTO.Request.createRuleRequestDTO(ruleNames: ruleNames)
-    //        )
-    //      }
-    //      .asDriver(onErrorJustReturn: 400)
+    
     return Output(createdRule: savedCompleted)
   }
 

--- a/Hous-iOS-release/Scene/OurRule/AddEdit/Cells/TitleDetailCollectionViewCell.swift
+++ b/Hous-iOS-release/Scene/OurRule/AddEdit/Cells/TitleDetailCollectionViewCell.swift
@@ -6,7 +6,7 @@
 //
 
 import UIKit
-
+import RxSwift
 import HousUIComponent
 
 final class TitleDetailCollectionViewCell: UICollectionViewCell {
@@ -18,7 +18,7 @@ final class TitleDetailCollectionViewCell: UICollectionViewCell {
       $0.applyColor(to: "*", with: .red)
     }
 
-  private let textField = FilledHousTextField(maxCount: 20)
+  let textField = FilledHousTextField(maxCount: 20)
 
   private let descriptionLabel = HousLabel(
     text: StringLiterals.OurRule.AddEditView.description,
@@ -26,7 +26,14 @@ final class TitleDetailCollectionViewCell: UICollectionViewCell {
     textColor: Colors.black.color
   )
 
-  private let textView = HousTextView(maxCount: 50)
+  let textView = HousTextView(maxCount: 50)
+
+  var disposeBag = DisposeBag()
+
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    disposeBag = DisposeBag()
+  }
 
   override init(frame: CGRect) {
     super.init(frame: frame)
@@ -38,7 +45,7 @@ final class TitleDetailCollectionViewCell: UICollectionViewCell {
   }
 
   private func setLayout() {
-    [titleLabel, descriptionLabel, textView].forEach {
+    [titleLabel, textField, descriptionLabel, textView].forEach {
       contentView.addSubview($0)
     }
     titleLabel.snp.makeConstraints { make in

--- a/Hous-iOS-release/Scene/OurRule/AddRuleView/AddRuleViewController.swift
+++ b/Hous-iOS-release/Scene/OurRule/AddRuleView/AddRuleViewController.swift
@@ -87,7 +87,7 @@ final class AddRuleViewController: BaseViewController, LoadingPresentable {
     configUI()
     setTableView()
     bind()
-    configButtonAction()
+//    configButtonAction()
     setNoti()
   }
 
@@ -214,74 +214,63 @@ final class AddRuleViewController: BaseViewController, LoadingPresentable {
       .setDelegate(self)
       .disposed(by: disposeBag)
 
-    let input = AddRuleViewModel.Input(
-      navBackButtonDidTapped: navigationBar.backButton.rx.tap.asObservable(),
-      viewDidTapped: view.rx.tapGesture().asObservable(),
-      saveButtonDidTapped: newRulesSubject
-        .do(onNext: { [weak self] _ in self?.showLoading() }),
-      plusButtonDidTapped: plusButton.rx.tap.asObservable(),
-      textFieldEdit: ruleTextField.rx.text
-        .orEmpty
-        .distinctUntilChanged()
-        .asObservable()
-    )
+//    let input = AddRuleViewModel.Input(
+//      navBackButtonDidTapped: navigationBar.backButton.rx.tap.asObservable(),
+//      viewDidTapped: view.rx.tapGesture().asObservable(),
+//      saveButtonDidTapped: newRulesSubject
+//        .do(onNext: { [weak self] _ in self?.showLoading() }),
+//      plusButtonDidTapped: plusButton.rx.tap.asObservable(),
+//      textFieldEdit: ruleTextField.rx.text
+//        .orEmpty
+//        .distinctUntilChanged()
+//        .asObservable()
+//    )
+//
+//    let output = viewModel.transform(input: input)
+//
+//    output.navBackButtonDidTapped
+//      .drive(onNext: { [weak self] _ in
+//        guard let self = self else { return }
+//
+//        if self.newRules.count != 0 || (self.ruleTextField.text?.count ?? 0) > 0 {
+//          self.showQuitPopUp()
+//          return
+//        }
+//
+//        self.navigationController?.popViewController(animated: true)
+//      })
+//      .disposed(by: disposeBag)
+//
+//    output.viewDidTapped
+//      .drive(onNext: { [weak self] _ in
+//        guard let self = self else { return }
+//        self.ruleTextField.endEditing(true)
+//      })
+//      .disposed(by: disposeBag)
+//
+//    output.plusButtonDidTapped
+//      .drive(onNext: { [weak self] _ in
+//        guard let self = self,
+//              let text = self.ruleTextField.text
+//        else { return }
+//
+//        if self.rules.count >= 30 {
+//          self.showExceedPopup()
+//        } else {
+//          self.rules.append(text)
+//          self.newRules.append(text)
+//          self.rulesSubject.onNext(self.rules)
+//
+//          self.ruleTextField.text = ""
+//          self.navigationBar.rightButton.isEnabled = true
+//          self.ruleTableView.reloadData()
+//        }
+//      })
+//      .disposed(by: disposeBag)
 
-    let output = viewModel.transform(input: input)
-
-    output.navBackButtonDidTapped
-      .drive(onNext: { [weak self] _ in
-        guard let self = self else { return }
-
-        if self.newRules.count != 0 || (self.ruleTextField.text?.count ?? 0) > 0 {
-          self.showQuitPopUp()
-          return
-        }
-
-        self.navigationController?.popViewController(animated: true)
-      })
-      .disposed(by: disposeBag)
-
-    output.viewDidTapped
-      .drive(onNext: { [weak self] _ in
-        guard let self = self else { return }
-        self.ruleTextField.endEditing(true)
-      })
-      .disposed(by: disposeBag)
-
-    output.plusButtonDidTapped
-      .drive(onNext: { [weak self] _ in
-        guard let self = self,
-              let text = self.ruleTextField.text
-        else { return }
-
-        if self.rules.count >= 30 {
-          self.showExceedPopup()
-        } else {
-          self.rules.append(text)
-          self.newRules.append(text)
-          self.rulesSubject.onNext(self.rules)
-
-          self.ruleTextField.text = ""
-          self.navigationBar.rightButton.isEnabled = true
-          self.ruleTableView.reloadData()
-        }
-      })
-      .disposed(by: disposeBag)
-
-    output.isEnableStatusOfSaveButton
-      .drive(plusButton.rx.isUserInteractionEnabled)
-      .disposed(by: disposeBag)
-
-    output.savedCompleted
-      .do(onNext: { [weak self] _ in self?.hideLoading() })
-      .drive(onNext: { [weak self] _ in
-        self?.navigationController?.popViewController(animated: true)
-      })
-      .disposed(by: disposeBag)
-
-    output.textCountLabelText
-      .drive(textCountLabel.rx.text)
-      .disposed(by: disposeBag)
+//    output.isEnableStatusOfSaveButton
+//      .drive(plusButton.rx.isUserInteractionEnabled)
+//      .disposed(by: disposeBag)
     }
 
   private func configButtonAction() {

--- a/Hous-iOS-release/Scene/OurRule/AddRuleView/AddRuleViewModel.swift
+++ b/Hous-iOS-release/Scene/OurRule/AddRuleView/AddRuleViewModel.swift
@@ -17,7 +17,7 @@ class AddRuleViewModel: ViewModelType {
   struct Input {
     let navBackButtonDidTapped: Observable<Void>
     let viewDidTapped: Observable<UITapGestureRecognizer>
-    let saveButtonDidTapped: Observable<[String]>
+//    let saveButtonDidTapped: Observable<[String]>
     let plusButtonDidTapped: Observable<Void>
     let textFieldEdit: Observable<String>
   }
@@ -25,7 +25,7 @@ class AddRuleViewModel: ViewModelType {
   struct Output {
     let navBackButtonDidTapped: Driver<Void>
     let viewDidTapped: Driver<UITapGestureRecognizer>
-    let savedCompleted: Driver<Int>
+//    let savedCompleted: Driver<Int>
     let plusButtonDidTapped: Driver<Void>
     let isEnableStatusOfSaveButton: Driver<Bool>
     let textCountLabelText: Driver<String>
@@ -33,13 +33,13 @@ class AddRuleViewModel: ViewModelType {
   }
 
   func transform(input: Input) -> Output {
-    let savedCompleted = input.saveButtonDidTapped
-      .flatMap { ruleNames -> Observable<Int> in
-        return NetworkService.shared.ruleRepository.createRules(
-          RuleDTO.Request.createRuleRequestDTO(ruleNames: ruleNames)
-        )
-      }
-      .asDriver(onErrorJustReturn: 400)
+//    let savedCompleted = input.saveButtonDidTapped
+//      .flatMap { ruleNames -> Observable<Int> in
+//        return NetworkService.shared.ruleRepository.createRules(
+//          RuleDTO.Request.createRuleRequestDTO(ruleNames: ruleNames)
+//        )
+//      }
+//      .asDriver(onErrorJustReturn: 400)
 
     let isEnableStatusOfSaveButton = input.textFieldEdit.map { string in
       return string.trimmingCharacters(in: .whitespaces).count != 0
@@ -63,7 +63,7 @@ class AddRuleViewModel: ViewModelType {
     return Output(
       navBackButtonDidTapped: input.navBackButtonDidTapped.asDriver(onErrorJustReturn: ()),
       viewDidTapped: input.viewDidTapped.asDriver(onErrorJustReturn: UITapGestureRecognizer()),
-      savedCompleted: savedCompleted,
+//      savedCompleted: savedCompleted,
       plusButtonDidTapped: input.plusButtonDidTapped.asDriver(onErrorJustReturn: ()),
       isEnableStatusOfSaveButton: isEnableStatusOfSaveButton,
       textCountLabelText: textCount,

--- a/Hous-iOS-release/Scene/OurRule/DeleteRuleView/DeleteRuleViewController.swift
+++ b/Hous-iOS-release/Scene/OurRule/DeleteRuleView/DeleteRuleViewController.swift
@@ -29,7 +29,7 @@ class DeleteRuleViewController: BaseViewController, LoadingPresentable {
   }
 
   // MARK: - var & let
-  private let viewModel: DeleteRuleViewModel
+//  private let viewModel: DeleteRuleViewModel
 
   private let rules: [HousRule]
 
@@ -40,9 +40,13 @@ class DeleteRuleViewController: BaseViewController, LoadingPresentable {
   private var deleteButtonDidTapped = PublishSubject<[Int]>()
 
   // MARK: - Lifecycle
-  init(rules: [HousRule], viewModel: DeleteRuleViewModel) {
+//  init(rules: [HousRule], viewModel: DeleteRuleViewModel) {
+//    self.rules = rules
+//    self.viewModel = viewModel
+//    super.init(nibName: nil, bundle: nil)
+//  }
+  init(rules: [HousRule]) {
     self.rules = rules
-    self.viewModel = viewModel
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -189,26 +193,26 @@ class DeleteRuleViewController: BaseViewController, LoadingPresentable {
     bindTableView()
     configButtonAction()
 
-    let input = DeleteRuleViewModel.Input(
-      deleteButtonDidTapped: deleteButtonDidTapped
-        .do(onNext: { [weak self] _ in self?.showLoading() }),
-      navBackButtonDidTapped: navigationBar.backButton.rx.tap.asObservable())
-
-    let output = viewModel.transform(input: input)
-
-    output.moveToMainRuleView
-      .drive(onNext: { [weak self] _ in
-        guard let self = self else { return }
-        self.navigationController?.popViewController(animated: true)
-      })
-      .disposed(by: disposeBag)
-
-    output.deletedCompleted
-      .do(onNext: { [weak self] _ in self?.hideLoading() })
-      .drive(onNext: {
-        self.navigationController?.popViewController(animated: true)
-      })
-      .disposed(by: disposeBag)
+//    let input = DeleteRuleViewModel.Input(
+//      deleteButtonDidTapped: deleteButtonDidTapped
+//        .do(onNext: { [weak self] _ in self?.showLoading() }),
+//      navBackButtonDidTapped: navigationBar.backButton.rx.tap.asObservable())
+//
+//    let output = viewModel.transform(input: input)
+//
+//    output.moveToMainRuleView
+//      .drive(onNext: { [weak self] _ in
+//        guard let self = self else { return }
+//        self.navigationController?.popViewController(animated: true)
+//      })
+//      .disposed(by: disposeBag)
+//
+//    output.deletedCompleted
+//      .do(onNext: { [weak self] _ in self?.hideLoading() })
+//      .drive(onNext: {
+//        self.navigationController?.popViewController(animated: true)
+//      })
+//      .disposed(by: disposeBag)
 
   }
 

--- a/Hous-iOS-release/Scene/OurRule/DeleteRuleView/DeleteRuleViewModel.swift
+++ b/Hous-iOS-release/Scene/OurRule/DeleteRuleView/DeleteRuleViewModel.swift
@@ -10,30 +10,30 @@ import RxSwift
 import RxCocoa
 import Network
 
-class DeleteRuleViewModel: ViewModelType {
-  struct Input {
-    let deleteButtonDidTapped: Observable<[Int]>
-    let navBackButtonDidTapped: Observable<Void>
-  }
+// class DeleteRuleViewModel: ViewModelType {
+//  struct Input {
+//    let deleteButtonDidTapped: Observable<[Int]>
+//    let navBackButtonDidTapped: Observable<Void>
+//  }
+//
+//  struct Output {
+//    let deletedCompleted: Driver<Void>
+//    let moveToMainRuleView: Driver<Void>
+//  }
 
-  struct Output {
-    let deletedCompleted: Driver<Void>
-    let moveToMainRuleView: Driver<Void>
-  }
+//  func transform(input: Input) -> Output {
+//    let deletedCompleted = input.deleteButtonDidTapped.flatMap { ruleId in
+//      return NetworkService.shared
+//        .ruleRepository
+//        .deleteRules(
+//        RuleDTO.Request.deleteRulesRequestDTO(rulesIdList: ruleId))
+//    }
+//    .asDriver(onErrorJustReturn: ())
+//
+//    return Output(
+//      deletedCompleted: deletedCompleted,
+//      moveToMainRuleView: input.navBackButtonDidTapped.asDriver(onErrorJustReturn: ())
+//    )
 
-  func transform(input: Input) -> Output {
-    let deletedCompleted = input.deleteButtonDidTapped.flatMap { ruleId in
-      return NetworkService.shared
-        .ruleRepository
-        .deleteRules(
-        RuleDTO.Request.deleteRulesRequestDTO(rulesIdList: ruleId))
-    }
-    .asDriver(onErrorJustReturn: ())
-
-    return Output(
-      deletedCompleted: deletedCompleted,
-      moveToMainRuleView: input.navBackButtonDidTapped.asDriver(onErrorJustReturn: ())
-    )
-
-  }
-}
+//  }
+// }

--- a/Hous-iOS-release/Scene/OurRule/EditRuleView/EditRuleViewController.swift
+++ b/Hous-iOS-release/Scene/OurRule/EditRuleView/EditRuleViewController.swift
@@ -260,14 +260,14 @@ final class EditRuleViewController: BaseViewController, LoadingPresentable {
 
     let output = viewModel.transform(input: input)
 
-    output.saveCompleted
-      .do(onNext: { [weak self] _ in
-        self?.hideLoading()
-      })
-      .drive(onNext: { [weak self] _ in
-        self?.navigationController?.popViewController(animated: true)
-      })
-      .disposed(by: disposeBag)
+//    output.saveCompleted
+//      .do(onNext: { [weak self] _ in
+//        self?.hideLoading()
+//      })
+//      .drive(onNext: { [weak self] _ in
+//        self?.navigationController?.popViewController(animated: true)
+//      })
+//      .disposed(by: disposeBag)
 
     output.moveToRuleMainView
       .drive(onNext: { [weak self] _ in

--- a/Hous-iOS-release/Scene/OurRule/EditRuleView/EditRuleViewModel.swift
+++ b/Hous-iOS-release/Scene/OurRule/EditRuleView/EditRuleViewModel.swift
@@ -18,7 +18,7 @@ final class EditRuleViewModel: ViewModelType {
   }
 
   struct Output {
-    let saveCompleted: Driver<Void>
+//    let saveCompleted: Driver<Void>
     let moveToRuleMainView: Driver<Void>
   }
 
@@ -35,18 +35,18 @@ final class EditRuleViewModel: ViewModelType {
         return ruleDTO
       }
 
-    let ruleDriver = ruleDTO.flatMap { dto in
-      NetworkService.shared.ruleRepository.updateRules(
-        RuleDTO.Request.updateRulesRequestDTO(rules: dto)
-      )
-    }
-      .asDriver(onErrorJustReturn: ())
+//    let ruleDriver = ruleDTO.flatMap { dto in
+//      NetworkService.shared.ruleRepository.updateRules(
+//        RuleDTO.Request.updateRulesRequestDTO(rules: dto)
+//      )
+//    }
+//      .asDriver(onErrorJustReturn: ())
 
     let moveToRuleMainView = input.backButtonDidTap
       .asDriver(onErrorJustReturn: ())
 
     return Output(
-      saveCompleted: ruleDriver,
+//      saveCompleted: ruleDriver,
       moveToRuleMainView: moveToRuleMainView
     )
 

--- a/Hous-iOS-release/Scene/OurRule/MainRule/RulesViewController.swift
+++ b/Hous-iOS-release/Scene/OurRule/MainRule/RulesViewController.swift
@@ -90,10 +90,14 @@ final class RulesViewController: BaseViewController, LoadingPresentable {
         let moreButtonDidTap = navigationBar.rightButton.rx.tap
         .asObservable()
 
+        let plusButtonDidTap = floatingButton.rx.tap.asObservable()
+
         let input = RulesViewModel.Input(
           viewWillAppear: viewWillAppear,
           backButtonDidTapped: backbuttonDidTap,
-          moreButtonDidTapped: moreButtonDidTap)
+          moreButtonDidTapped: moreButtonDidTap,
+          plusButtonDidTapped: plusButtonDidTap
+        )
 
         let output = viewModel.transform(input: input)
 
@@ -117,6 +121,14 @@ final class RulesViewController: BaseViewController, LoadingPresentable {
         UIView.animate(withDuration: 0.3) {
           self.housMenu.alpha = alpha
         }
+      }
+      .disposed(by: disposeBag)
+
+    output.presentAddViewController
+      .drive { [weak self] _ in
+        guard let self else { return }
+        let viewController = AddEditRuleViewController(viewModel: AddEditViewModel())
+        self.navigationController?.pushViewController(viewController, animated: true)
       }
       .disposed(by: disposeBag)
 

--- a/Hous-iOS-release/Scene/OurRule/MainRule/RulesViewController.swift
+++ b/Hous-iOS-release/Scene/OurRule/MainRule/RulesViewController.swift
@@ -312,7 +312,6 @@ private extension RulesViewController {
       case .cancel, .add:
         return
       case .modify:
-        // TODO: - 새로만든 AddEdit뷰컨으로 넘기기
         viewController = AddEditRuleViewController(viewModel: AddEditViewModel(), type: .updateRule, model: model)
       case .delete:
         guard let ruleId = model.ruleId else { return }
@@ -338,14 +337,6 @@ private extension RulesViewController {
       guard let self = self else { return }
       switch actionType {
       case .action:
-        /*
-         ruleId를 위에 선언한 subject로 넘기고 <- 여기서 할일 : done
-         viewModel에서 해당 subject Input으로 받고
-         규칙 삭제 API 호출하고
-         해당 결과 받으면 popUp dismiss <- bind
-         그리고 collectionview에 바로 결과 반영시켜줘야한다.
-
-         */
         guard let selectedRuleId else { return }
         self.toDeleteRuleIdSubject.onNext(selectedRuleId)
       case .cancel:

--- a/Hous-iOS-release/Scene/OurRule/MainRule/RulesViewController.swift
+++ b/Hous-iOS-release/Scene/OurRule/MainRule/RulesViewController.swift
@@ -136,7 +136,7 @@ final class RulesViewController: BaseViewController, LoadingPresentable {
     output.presentAddViewController
       .drive { [weak self] _ in
         guard let self else { return }
-        let viewController = AddEditRuleViewController(viewModel: AddEditViewModel())
+        let viewController = AddEditRuleViewController(viewModel: AddEditViewModel(), type: .addRule)
         self.navigationController?.pushViewController(viewController, animated: true)
       }
       .disposed(by: disposeBag)
@@ -151,12 +151,13 @@ final class RulesViewController: BaseViewController, LoadingPresentable {
           return BottomSheetKit.RulePhoto(image: $0)
         }
 
-        let cellModel = PhotoCellModel(title: dto.name,
+        let cellModel = PhotoCellModel(ruleId: dto.id,
+                                       title: dto.name,
                                        description: dto.description,
                                        lastmodifedDate: dto.updatedAt,
                                        photos: photos.isEmpty ? nil : photos)
 
-        self.showBottomSheet(model: cellModel, ruleId: dto.id)
+        self.showBottomSheet(model: cellModel)
       })
       .disposed(by: disposeBag)
 
@@ -299,11 +300,9 @@ extension RulesViewController {
 }
 
 private extension RulesViewController {
-  func showBottomSheet(model: PhotoCellModel, ruleId: Int) {
+  func showBottomSheet(model: PhotoCellModel) {
 
     let bottomSheetType = BottomSheetType.ruleType(model)
-
-    let ruleList = self.rules.map { $0.name }
 
     self.presentBottomSheet(bottomSheetType) { actionType in
 
@@ -314,9 +313,9 @@ private extension RulesViewController {
         return
       case .modify:
         // TODO: - 새로만든 AddEdit뷰컨으로 넘기기
-        viewController = EditRuleViewController(editViewRules: self.rules, viewModel: EditRuleViewModel())
+        viewController = AddEditRuleViewController(viewModel: AddEditViewModel(), type: .updateRule, model: model)
       case .delete:
-        // TODO: - 삭제 팝업 띄우기
+        guard let ruleId = model.ruleId else { return }
         self.dismiss(animated: false) {
           self.showDeletePopUp(ruleId: ruleId)
         }
@@ -339,7 +338,6 @@ private extension RulesViewController {
       guard let self = self else { return }
       switch actionType {
       case .action:
-        // TODO: 규칙 삭제 API
         /*
          ruleId를 위에 선언한 subject로 넘기고 <- 여기서 할일 : done
          viewModel에서 해당 subject Input으로 받고

--- a/Hous-iOS-release/Scene/OurRule/MainRule/RulesViewModel.swift
+++ b/Hous-iOS-release/Scene/OurRule/MainRule/RulesViewModel.swift
@@ -17,6 +17,7 @@ final class RulesViewModel: ViewModelType {
     let viewWillAppear: Observable<Void>
     let backButtonDidTapped: Observable<Void>
     let moreButtonDidTapped: Observable<Void>
+    let plusButtonDidTapped: Observable<Void>
   }
 
   // MARK: - Outputs
@@ -24,6 +25,7 @@ final class RulesViewModel: ViewModelType {
     var rules: Driver<[HousRule]>
     var popViewController: Driver<Void>
     var presentBottomSheet: Driver<Void>
+    var presentAddViewController: Driver<Void>
   }
 
   private let housRulesSubject = PublishSubject<[HousRule]>()
@@ -43,10 +45,13 @@ final class RulesViewModel: ViewModelType {
     let housRules = housRulesSubject.asDriver(onErrorJustReturn: [])
     let popViewController = input.backButtonDidTapped.asDriver(onErrorJustReturn: ())
     let presentBottomSheet = input.moreButtonDidTapped.asDriver(onErrorJustReturn: ())
+    let plusButtonDidTapped = input.plusButtonDidTapped
+      .asDriver(onErrorJustReturn: ())
 
     return Output(rules: housRules,
                   popViewController: popViewController,
-                  presentBottomSheet: presentBottomSheet)
+                  presentBottomSheet: presentBottomSheet,
+                  presentAddViewController: plusButtonDidTapped)
   }
 
   init(repositoryProvider: ServiceProviderType) {

--- a/Hous-iOS-release/Scene/TestScene/TestViewController.swift
+++ b/Hous-iOS-release/Scene/TestScene/TestViewController.swift
@@ -319,8 +319,8 @@ extension TestViewController {
                                description: "옷걸이에 걸어두면 바나나는 자기가 아직도 나무에 걸려있다고 착각하고 싱싱한 상태를 유지한대..귀여워서 기절",
                                lastmodifedDate: "마지막 수정 2023.04.01",
                                photos: [
-                                .init(image: UIImage(systemName: "star.fill")!),
-                                .init(image: UIImage(systemName: "star")!)
+                                .init(image: "https://team-hous.s3.ap-northeast-2.amazonaws.com/rule-image/data/v1-51215f53-2126-4f80-80b5-2f2d8106103e.jpeg"),
+                                .init(image: "https://team-hous.s3.ap-northeast-2.amazonaws.com/rule-image/data/v1-a67b1515-c682-475b-ad22-f80a29c30494.jpeg")
                                ])
 
     self.presentBottomSheet(.ruleType(model)) { actionType in

--- a/HousUIComponent/Sources/HousUIComponent/TextField/FilledHousTextField.swift
+++ b/HousUIComponent/Sources/HousUIComponent/TextField/FilledHousTextField.swift
@@ -11,6 +11,12 @@ import AssetKit
 
 public final class FilledHousTextField: UITextField {
 
+    public override var text: String? {
+        didSet {
+            textCountLabel.text = "\(text?.count ?? 0)/\(maxCount)"
+        }
+    }
+
   private let maxCount: Int
 
   private let baseRightView = UIView()

--- a/Network/Sources/Network/API/AuthAPI/AuthService.swift
+++ b/Network/Sources/Network/API/AuthAPI/AuthService.swift
@@ -24,15 +24,15 @@ extension AuthService: TargetType {
   public var path: String {
     switch self {
     case .login:
-      return "auth/login"
+      return "/v1/auth/login"
     case .refresh:
-      return "auth/refresh"
+      return "/v1/auth/refresh"
     case .signup:
-      return "auth/signup"
+      return "/v1/auth/signup"
     case .forceLogin:
-      return "auth/login/force"
+      return "/v1/auth/login/force"
     case .logout:
-      return "auth/logout"
+      return "/v1/auth/logout"
     }
   }
 

--- a/Network/Sources/Network/API/MainHomeAPI/MainHomeService.swift
+++ b/Network/Sources/Network/API/MainHomeAPI/MainHomeService.swift
@@ -20,7 +20,7 @@ extension MainHomeService: TargetType {
   public var path: String {
     switch self {
     case .getHomeData:
-      return "/home"
+      return "/v1/home"
     }
   }
   

--- a/Network/Sources/Network/API/RoomAPI/RoomService.swift
+++ b/Network/Sources/Network/API/RoomAPI/RoomService.swift
@@ -24,15 +24,15 @@ extension RoomService: TargetType {
   public var path: String {
     switch self {
     case .postNewRoom:
-      return "/room"
+      return "/v1/room"
     case let .postExistRoom(roomId):
-      return "/room/\(roomId)/join"
+      return "/v1/room/\(roomId)/join"
     case .getIsExistRoom:
-      return "/room/info"
+      return "/v1/room/info"
     case .updateRoomName:
-      return "/room/name"
+      return "/v1/room/name"
     case .leaveRoom:
-      return "/room/leave"
+      return "/v1/room/leave"
     }
   }
   

--- a/Network/Sources/Network/API/RuleAPI/RuleAPI.swift
+++ b/Network/Sources/Network/API/RuleAPI/RuleAPI.swift
@@ -12,7 +12,7 @@ protocol RuleAPIProtocol {
     func getRulesName() -> Observable<[RuleDTO.Response.Rule]>
     func updateRules(_ ruleRequestDTO: RuleDTO.Request.updateRulesRequestDTO) -> Observable<Void>
     func createRules(_ ruleRequestDTO: RuleDTO.Request.createRuleRequestDTO, images: [UIImage]) -> Observable<Int>
-    func deleteRules(_ ruleRequestDTO: RuleDTO.Request.deleteRulesRequestDTO) -> Observable<Void>
+    func deleteRule(ruleId: Int) -> Observable<Int>
     func getRuleDetail(ruleId: Int) -> Observable<RuleDTO.Response.SingleRuleResponseDTO?>
 }
 
@@ -38,11 +38,11 @@ public final class RuleAPI: APIRequestLoader<RuleService>, RuleAPIProtocol {
         }
     }
 
-    public func deleteRules(_ ruleRequestDTO: RuleDTO.Request.deleteRulesRequestDTO) -> RxSwift.Observable<Void> {
+    public func deleteRule(ruleId: Int) -> RxSwift.Observable<Int> {
         return Observable.create { [weak self] emitter in
             
             self?.fetchData(
-                target: .deleteRule(ruleRequestDTO),
+                target: .deleteRule(ruleId: ruleId),
                 responseData: BaseResponseType<RuleDTO.Response.updateRulesResponseDTO>.self
             ) { result, error in
                 if let error = error {
@@ -50,7 +50,7 @@ public final class RuleAPI: APIRequestLoader<RuleService>, RuleAPIProtocol {
                 }
                 
                 if result != nil {
-                    emitter.onNext(())
+                    emitter.onNext(ruleId)
                     emitter.onCompleted()
                 }
             }

--- a/Network/Sources/Network/API/RuleAPI/RuleAPI.swift
+++ b/Network/Sources/Network/API/RuleAPI/RuleAPI.swift
@@ -13,9 +13,31 @@ protocol RuleAPIProtocol {
     func updateRules(_ ruleRequestDTO: RuleDTO.Request.updateRulesRequestDTO) -> Observable<Void>
     func createRules(_ ruleRequestDTO: RuleDTO.Request.createRuleRequestDTO, images: [UIImage]) -> Observable<Int>
     func deleteRules(_ ruleRequestDTO: RuleDTO.Request.deleteRulesRequestDTO) -> Observable<Void>
+    func getRuleDetail(ruleId: Int) -> Observable<RuleDTO.Response.SingleRuleResponseDTO?>
 }
 
 public final class RuleAPI: APIRequestLoader<RuleService>, RuleAPIProtocol {
+    public func getRuleDetail(ruleId: Int) -> RxSwift.Observable<RuleDTO.Response.SingleRuleResponseDTO?> {
+        return Observable.create { [weak self] emitter in
+
+            self?.fetchData(
+                target: .getRuleDetail(ruleId: ruleId),
+                responseData: BaseResponseType<RuleDTO.Response.SingleRuleResponseDTO>.self
+            ) { result, error in
+                if let error = error {
+                    emitter.onError(error)
+                }
+
+                if result != nil {
+                    emitter.onNext(result?.data)
+                    emitter.onCompleted()
+                }
+            }
+
+            return Disposables.create()
+        }
+    }
+
     public func deleteRules(_ ruleRequestDTO: RuleDTO.Request.deleteRulesRequestDTO) -> RxSwift.Observable<Void> {
         return Observable.create { [weak self] emitter in
             
@@ -40,7 +62,7 @@ public final class RuleAPI: APIRequestLoader<RuleService>, RuleAPIProtocol {
     public func createRules(_ ruleRequestDTO: RuleDTO.Request.createRuleRequestDTO, images: [UIImage]) -> RxSwift.Observable<Int> {
         return Observable.create { [weak self] emitter in
             
-            self?.fetchData(
+            self?.fetchDataMultiPart(
                 target: .createRule(ruleRequestDTO, images: images),
                 responseData: BaseResponseType<RuleDTO.Response.updateRulesResponseDTO>.self
             ) { result, error in

--- a/Network/Sources/Network/API/RuleAPI/RuleAPI.swift
+++ b/Network/Sources/Network/API/RuleAPI/RuleAPI.swift
@@ -10,7 +10,7 @@ import RxSwift
 
 protocol RuleAPIProtocol {
     func getRulesName() -> Observable<[RuleDTO.Response.Rule]>
-    func updateRules(_ ruleRequestDTO: RuleDTO.Request.updateRulesRequestDTO) -> Observable<Void>
+    func updateRule(_ ruleRequestDTO: RuleDTO.Request.createRuleRequestDTO, ruleId: Int, images: [UIImage]) -> Observable<Int>
     func createRules(_ ruleRequestDTO: RuleDTO.Request.createRuleRequestDTO, images: [UIImage]) -> Observable<Int>
     func deleteRule(ruleId: Int) -> Observable<Int>
     func getRuleDetail(ruleId: Int) -> Observable<RuleDTO.Response.SingleRuleResponseDTO?>
@@ -82,22 +82,23 @@ public final class RuleAPI: APIRequestLoader<RuleService>, RuleAPIProtocol {
         }
     }
     
-    public func updateRules(_ ruleRequestDTO: RuleDTO.Request.updateRulesRequestDTO) -> Observable<Void> {
+    public func updateRule(_ ruleRequestDTO: RuleDTO.Request.createRuleRequestDTO, ruleId: Int, images: [UIImage]) -> Observable<Int> {
         
         return Observable.create { [weak self] emitter in
             
-            self?.fetchData(
-                target: .updateRules(ruleRequestDTO),
+            self?.fetchDataMultiPart(
+                target: .updateRule(ruleRequestDTO, ruleId: ruleId, images: images),
                 responseData: BaseResponseType<RuleDTO.Response.updateRulesResponseDTO>.self
             ) { result, error in
                 if let error = error {
                     emitter.onError(error)
                 }
                 
-                if result != nil {
-                    emitter.onNext(())
-                    emitter.onCompleted()
+                guard let result else {
+                    return
                 }
+                emitter.onNext(result.status)
+                emitter.onCompleted()
             }
             
             return Disposables.create()

--- a/Network/Sources/Network/API/RuleAPI/RuleAPI.swift
+++ b/Network/Sources/Network/API/RuleAPI/RuleAPI.swift
@@ -5,13 +5,13 @@
 //  Created by 김민재 on 2022/10/28.
 //
 
-import Foundation
+import UIKit
 import RxSwift
 
 protocol RuleAPIProtocol {
     func getRulesName() -> Observable<[RuleDTO.Response.Rule]>
     func updateRules(_ ruleRequestDTO: RuleDTO.Request.updateRulesRequestDTO) -> Observable<Void>
-    func createRules(_ ruleRequestDTO: RuleDTO.Request.createRuleRequestDTO) -> Observable<Int>
+    func createRules(_ ruleRequestDTO: RuleDTO.Request.createRuleRequestDTO, images: [UIImage]) -> Observable<Int>
     func deleteRules(_ ruleRequestDTO: RuleDTO.Request.deleteRulesRequestDTO) -> Observable<Void>
 }
 
@@ -37,11 +37,11 @@ public final class RuleAPI: APIRequestLoader<RuleService>, RuleAPIProtocol {
         }
     }
     
-    public func createRules(_ ruleRequestDTO: RuleDTO.Request.createRuleRequestDTO) -> RxSwift.Observable<Int> {
+    public func createRules(_ ruleRequestDTO: RuleDTO.Request.createRuleRequestDTO, images: [UIImage]) -> RxSwift.Observable<Int> {
         return Observable.create { [weak self] emitter in
             
             self?.fetchData(
-                target: .createRule(ruleRequestDTO),
+                target: .createRule(ruleRequestDTO, images: images),
                 responseData: BaseResponseType<RuleDTO.Response.updateRulesResponseDTO>.self
             ) { result, error in
                 if let error = error {

--- a/Network/Sources/Network/API/RuleAPI/RuleService.swift
+++ b/Network/Sources/Network/API/RuleAPI/RuleService.swift
@@ -20,7 +20,7 @@ extension RuleService: TargetType {
   public var baseURL: String {
     return API.apiBaseURL
   }
-  
+
   public var path: String {
     switch self {
     case .deleteRule,
@@ -68,7 +68,6 @@ extension RuleService: TargetType {
 
       for (index, image) in images.enumerated() {
           if  let jpegData = image.jpegData(compressionQuality: 0.2) {
-              print(jpegData)
             multiPart.append(jpegData, withName: "images", fileName: "image-\(index).jpeg", mimeType: "image/jpeg")
         }
       }

--- a/Network/Sources/Network/API/RuleAPI/RuleService.swift
+++ b/Network/Sources/Network/API/RuleAPI/RuleService.swift
@@ -10,7 +10,7 @@ import Alamofire
 
 public enum RuleService {
   case createRule(_ dto: RuleDTO.Request.createRuleRequestDTO, images: [UIImage])
-  case updateRules(_ dto: RuleDTO.Request.updateRulesRequestDTO)
+    case updateRule(_ dto: RuleDTO.Request.createRuleRequestDTO, ruleId: Int, images: [UIImage])
   case deleteRule(ruleId: Int)
   case getRuleData
     case getRuleDetail(ruleId: Int)
@@ -23,9 +23,10 @@ extension RuleService: TargetType {
 
   public var path: String {
     switch self {
-    case .createRule,
-            .updateRules:
+    case .createRule:
         return "/v2/rule"
+    case let .updateRule(_, ruleId, _):
+        return "/v2/rule/\(ruleId)"
     case .getRuleData:
       return "/v1/rules"
     case .getRuleDetail(let ruleId):
@@ -39,7 +40,7 @@ extension RuleService: TargetType {
     switch self {
     case .createRule:
       return .post
-    case .updateRules:
+    case .updateRule:
       return .put
     case .deleteRule:
       return .delete
@@ -49,18 +50,15 @@ extension RuleService: TargetType {
   }
   
   public var parameters: RequestParams {
-    switch self {      
-    case .updateRules(let dto):
-      return .body(dto)
-
-    case .getRuleData, .getRuleDetail, .createRule, .deleteRule:
+    switch self {
+    case .getRuleData, .getRuleDetail, .createRule, .deleteRule, .updateRule:
       return .requestPlain
     }
   }
 
   public var multipart: MultipartFormData {
     switch self {
-    case .createRule(let dto, let images):
+    case .createRule(let dto, let images), .updateRule(let dto, _, let images):
       let multiPart = MultipartFormData()
 
       for (index, image) in images.enumerated() {

--- a/Network/Sources/Network/API/RuleAPI/RuleService.swift
+++ b/Network/Sources/Network/API/RuleAPI/RuleService.swift
@@ -11,7 +11,7 @@ import Alamofire
 public enum RuleService {
   case createRule(_ dto: RuleDTO.Request.createRuleRequestDTO, images: [UIImage])
   case updateRules(_ dto: RuleDTO.Request.updateRulesRequestDTO)
-  case deleteRule(_ dto: RuleDTO.Request.deleteRulesRequestDTO)
+  case deleteRule(ruleId: Int)
   case getRuleData
     case getRuleDetail(ruleId: Int)
 }
@@ -23,13 +23,14 @@ extension RuleService: TargetType {
 
   public var path: String {
     switch self {
-    case .deleteRule,
-            .createRule,
+    case .createRule,
             .updateRules:
         return "/v2/rule"
     case .getRuleData:
       return "/v1/rules"
     case .getRuleDetail(let ruleId):
+        return "/v2/rule/\(ruleId)"
+    case .deleteRule(let ruleId):
         return "/v2/rule/\(ruleId)"
     }
   }
@@ -51,13 +52,9 @@ extension RuleService: TargetType {
     switch self {      
     case .updateRules(let dto):
       return .body(dto)
-      
-    case .deleteRule(let dto):
-      return .body(dto)
 
-    case .getRuleData, .getRuleDetail, .createRule:
+    case .getRuleData, .getRuleDetail, .createRule, .deleteRule:
       return .requestPlain
-
     }
   }
 

--- a/Network/Sources/Network/API/RuleAPI/RuleService.swift
+++ b/Network/Sources/Network/API/RuleAPI/RuleService.swift
@@ -5,11 +5,11 @@
 //  Created by 김민재 on 2022/10/28.
 //
 
-import Foundation
+import UIKit
 import Alamofire
 
 public enum RuleService {
-  case createRule(_ dto: RuleDTO.Request.createRuleRequestDTO)
+  case createRule(_ dto: RuleDTO.Request.createRuleRequestDTO, images: [UIImage])
   case updateRules(_ dto: RuleDTO.Request.updateRulesRequestDTO)
   case deleteRule(_ dto: RuleDTO.Request.deleteRulesRequestDTO)
   case getRuleData
@@ -22,11 +22,12 @@ extension RuleService: TargetType {
   
   public var path: String {
     switch self {
-    case .createRule,
-        .updateRules,
-        .deleteRule,
-        .getRuleData:
-      return "/rules"
+    case .deleteRule,
+            .createRule,
+            .updateRules:
+        return "/v2/rule"
+    case .getRuleData:
+      return "/v1/rules"
     }
   }
   
@@ -45,8 +46,8 @@ extension RuleService: TargetType {
   
   public var parameters: RequestParams {
     switch self {
-    case .createRule(let dto):
-      return .body(dto)
+    case .createRule(let dto, _):
+      return .query(dto)
       
     case .updateRules(let dto):
       return .body(dto)
@@ -59,4 +60,19 @@ extension RuleService: TargetType {
 
     }
   }
+
+  public var multipart: MultipartFormData {
+    switch self {
+    case .createRule(_, let images):
+      let multiPart = MultipartFormData()
+      for (index, image) in images.enumerated() {
+        if let pngData = image.pngData() {
+          multiPart.append(pngData, withName: "image", fileName: "image-\(index).png", mimeType: "image/png")
+        }
+      }
+      return multiPart
+    default: return MultipartFormData()
+    }
+  }
+
 }

--- a/Network/Sources/Network/Base/TargetType.swift
+++ b/Network/Sources/Network/Base/TargetType.swift
@@ -14,6 +14,7 @@ public protocol TargetType: URLRequestConvertible {
   var method: HTTPMethod { get }
   var parameters: RequestParams { get }
   var contentType: ContentType { get }
+  var multipart: MultipartFormData { get }
 }
 
 public enum API {
@@ -33,12 +34,15 @@ enum HTTPHeaderField: String {
 public enum ContentType: String {
   case json = "Application/json"
   case image = "image/jpeg"
+  case multipart = "multipart/form-data"
 }
 
 public enum RequestParams {
   case requestPlain
   case query(_ parameter: Encodable?)
-  case body(_ parameter: Encodable?)}
+  case body(_ parameter: Encodable?)
+
+}
 
 extension TargetType {
 
@@ -69,7 +73,6 @@ extension TargetType {
       let params = request?.toDictionary() ?? [:]
       urlRequest.httpBody = try JSONSerialization.data(withJSONObject: params, options: [])
 
-
     case .requestPlain:
       break
     }
@@ -81,5 +84,9 @@ extension TargetType {
 public extension TargetType {
   var contentType: ContentType {
     return .json
+  }
+
+  var multipart: MultipartFormData {
+    return MultipartFormData()
   }
 }

--- a/Network/Sources/Network/Model/Rule/RuleRequestDTO.swift
+++ b/Network/Sources/Network/Model/Rule/RuleRequestDTO.swift
@@ -9,10 +9,12 @@ import Foundation
 
 public extension RuleDTO.Request {
     struct createRuleRequestDTO: Encodable {
-        public let ruleNames: [String]
+        public let name: String
+        public let description: String
         
-        public init(ruleNames: [String]) {
-            self.ruleNames = ruleNames
+        public init(name: String, description: String) {
+            self.name = name
+            self.description = description
         }
     }
     

--- a/Network/Sources/Network/Model/Rule/RuleResponseDTO.swift
+++ b/Network/Sources/Network/Model/Rule/RuleResponseDTO.swift
@@ -9,6 +9,14 @@ public extension RuleDTO.Response {
   struct RuleResponseDTO: Decodable {
     public let rules: [Rule]
   }
+
+  struct SingleRuleResponseDTO: Decodable {
+    public let id: Int
+    public let name: String
+    public let description: String
+    public let images: [String]
+    public let updatedAt: String
+  }
   
   struct Rule: Decodable {
     public let id: Int


### PR DESCRIPTION
## 🌱 작업한 내용
- [x] 규칙 추가 API
- [x] 규칙 수정 API
- [x] 규칙 상세정보 조회 API
- [x] 규칙 삭제 API

## 🌱 PR Point
현재 규칙을 추가할 때 사진을 여러장 보내면 앱서버 앞단에서 Ngnix에서 던지는 413 에러코드가 뜨는 상황입니다. 해당 에러를 찾아보니까 보내는 파일의 용량이 너무 클 때 ngnix에서 던지는 에러라고 하고 아무 설정도 안할시에 기본값이 1MB라고 하여 아마 용량에 걸리는 것 같습니다. (https://dobiho.com/57828/).
`let jpegData = image.jpegData(compressionQuality: 0)` 해당 코드로 최대한 압축해서 보내도 걸리기에 서버에 제한 용량을 조금 늘려달라고 요청했고 금요일에 수정해준다고 하네요.
테스트 스샷은 사진 1장만 넣어서 해보니까 잘됩니다.

-> 해결완료 (23.8.30)
서버에서 확인 후 수정해주어서 바로 변경했습니다.
[21f262b](https://github.com/Hous-Release/hous-iOS/commit/21f262b2949c1db357d072a8ecdc0e59b5ef7517)
[79275a1](https://github.com/Hous-Release/hous-iOS/commit/79275a18ac498d58e75416676668d45195a801b0)

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 규칙 API | ![RPReplay_Final1693403791](https://github.com/Hous-Release/hous-iOS/assets/60292150/be114ed6-d88d-458f-8a63-9edd9d104de6) |

## 📮 관련 이슈

- Resolved: #213 
