### PR TITLE
[FEAT] GroupActivity를 통한 초대코드 뎁스 간소화 (#224)

### DIFF
--- a/BottomSheetKit/Sources/BottomSheetKit/BottomSheetKit+.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/BottomSheetKit+.swift
@@ -159,6 +159,20 @@ public extension UIViewController {
         present(viewController, animated: false) {
             viewController.showBottomSheetWithAnimation()
         }
+    case .todoFilterType:
+        break
+//        let view = TodoFilterSheetView(<#TodoModel#>)
+//        let bottomSheetAction = RuleGuideBottomSheetAction(view: view)
+//        guard let viewController = RuleGuideBottomSheetViewController(action: bottomSheetAction) else { return }
+//
+//        bottomSheetAction.completeAction = { actionType in
+//            completion?(actionType)
+//        }
+//
+//        viewController.modalPresentationStyle = .overFullScreen
+//        present(viewController, animated: false) {
+//            viewController.showBottomSheetWithAnimation()
+//        }
     }
 
   }

--- a/BottomSheetKit/Sources/BottomSheetKit/Extensions/UIButton+.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/Extensions/UIButton+.swift
@@ -1,0 +1,31 @@
+//
+//  UIButton+.swift
+//
+//
+//  Created by 김민재 on 2/19/24.
+//
+
+import UIKit
+
+public extension UIButton {
+
+  var contentSizeWidth: CGFloat {
+    return intrinsicContentSize.width
+  }
+
+  var margin: CGFloat {
+    return (frame.width - contentSizeWidth) / 2
+  }
+
+  func setBackgroundColor(_ color: UIColor, for state: UIControl.State) {
+    UIGraphicsBeginImageContext(CGSize(width: 1.0, height: 1.0))
+    guard let context = UIGraphicsGetCurrentContext() else { return }
+    context.setFillColor(color.cgColor)
+    context.fill(CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0))
+
+    let backgroundImage = UIGraphicsGetImageFromCurrentImageContext()
+    UIGraphicsEndImageContext()
+
+    self.setBackgroundImage(backgroundImage, for: state)
+  }
+}

--- a/BottomSheetKit/Sources/BottomSheetKit/Model/BottomSheetModel.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/Model/BottomSheetModel.swift
@@ -21,4 +21,5 @@ public enum BottomSheetType {
   case todoType(TodoModel)
   case ruleType(PhotoCellModel)
     case ruleGuideType
+    case todoFilterType(TodoModel)
 }

--- a/BottomSheetKit/Sources/BottomSheetKit/TodoFilterBottomSheet/TodoFilterBottomSheetAction.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/TodoFilterBottomSheet/TodoFilterBottomSheetAction.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  
+//
+//  Created by 김민재 on 2/19/24.
+//
+
+import Foundation
+import UIKit
+
+final class TodoFilterBottomSheetAction: BottomSheetAction {
+  var view: TodoFilterSheetView
+  var completeAction: CompleteBottomSheetAction?
+
+  init(view: TodoFilterSheetView) { self.view = view }
+}

--- a/BottomSheetKit/Sources/BottomSheetKit/TodoFilterBottomSheet/TodoFilterSheetView.swift
+++ b/BottomSheetKit/Sources/BottomSheetKit/TodoFilterBottomSheet/TodoFilterSheetView.swift
@@ -1,0 +1,304 @@
+//
+//  TodoFilterSheetView.swift
+//
+//
+//  Created by 김민재 on 2/19/24.
+//
+
+import UIKit
+
+import AssetKit
+import HousUIComponent
+
+
+final class TodoFilterSheetView: UIView {
+  
+  private typealias SECTION = TodoBottomSheetDataSource.Section
+  private typealias ITEM = TodoBottomSheetDataSource.Item
+  private typealias DataSource = UICollectionViewDiffableDataSource<SECTION, ITEM>
+  private typealias SnapShot = NSDiffableDataSourceSnapshot<SECTION, ITEM>
+  private typealias CellRegistration = UICollectionView.CellRegistration
+  
+  private struct Constants {
+//    static let verticalMargin: CGFloat = 16
+//    static let horizontalMargin: CGFloat = 24
+    static let todoLabelTopMargin: CGFloat = 24
+    static let buttonHeight: CGFloat = 38
+    static let dayButtonSize: CGSize = CGSize(width: 40, height: 40)
+    static let verticalMargin: CGFloat = 12
+    static let horizontalMargin: CGFloat = 24
+    static let distance: CGFloat = 8
+  }
+  
+  private let rootView: UIView = {
+    let view = UIView()
+    view.layer.cornerRadius = 10
+    view.backgroundColor = .white
+    view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+    return view
+  }()
+  
+  private let titleLabel: UILabel = {
+    let label = UILabel()
+    label.text = "필터 설정"
+    label.font = Fonts.SpoqaHanSansNeo.bold.font(size: 18)
+    label.textColor = Colors.black.color
+    return label
+  }()
+  
+  private let dayTitleLabel: UILabel = {
+    let label = UILabel()
+    label.text = "요일"
+    label.font = Fonts.SpoqaHanSansNeo.medium.font(size: 16)
+    label.textColor = Colors.g3.color
+    return label
+  }()
+  
+  private let stackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .fill
+    stackView.distribution = .equalSpacing
+    stackView.spacing = Constants.distance
+    return stackView
+  }()
+  
+  private let homieTitleLabel: UILabel = {
+    let label = UILabel()
+    label.text = "호미"
+    label.font = Fonts.SpoqaHanSansNeo.medium.font(size: 16)
+    label.textColor = Colors.g3.color
+    return label
+  }()
+  
+  private let saveButton: UIButton = {
+    let button = UIButton()
+    button.setTitle("저장하기", for: .normal)
+    button.setTitleColor(Colors.white.color, for: .normal)
+    button.backgroundColor = Colors.blueL1.color
+    return button
+  }()
+  
+  private var collectionView: UICollectionView!
+  private var dataSource: DataSource!
+  private var snapShot: SnapShot!
+  
+  internal init(
+    _ model: TodoModel
+  ) {
+    
+    super.init(frame: .zero)
+    configureCollectionView()
+    configureDataSource()
+    setHierarchy()
+    setLayout()
+    applyInitialSnapshot()
+    applyHomiesSnapShot(model.homies.uniqued())
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setHierarchy() {
+    addSubview(rootView)
+    rootView.addSubViews([
+      titleLabel,
+      dayTitleLabel,
+      stackView,
+      homieTitleLabel,
+      collectionView,
+      saveButton
+    ])
+    
+    for day in Days.allCases {
+      let button = makeDayButton(day)
+      stackView.addArrangedSubview(button)
+
+      button.snp.makeConstraints { make in
+        make.height.equalTo(button.snp.width).multipliedBy(1)
+        make.height.greaterThanOrEqualTo(Constants.dayButtonSize.height)
+      }
+    }
+  }
+  
+  private func setLayout() {
+    rootView.snp.makeConstraints { make in
+      make.edges.equalToSuperview()
+    }
+    
+    titleLabel.snp.makeConstraints { make in
+      make.top.equalToSuperview().inset(30)
+      make.leading.equalToSuperview().inset(24)
+    }
+    
+    dayTitleLabel.snp.makeConstraints { make in
+      make.top.equalTo(titleLabel.snp.bottom).offset(20)
+      make.leading.equalTo(titleLabel)
+    }
+    
+    stackView.snp.makeConstraints { make in
+      make.top.equalTo(dayTitleLabel.snp.bottom).offset(8)
+      make.leading.trailing.equalToSuperview().inset(24)
+    }
+    
+    homieTitleLabel.snp.makeConstraints { make in
+      make.leading.equalTo(stackView)
+      make.top.equalTo(stackView.snp.bottom).offset(24)
+    }
+    
+    collectionView.snp.makeConstraints { make in
+      make.top.equalTo(homieTitleLabel.snp.bottom).offset(12)
+      make.leading.trailing.equalToSuperview()
+      make.height.greaterThanOrEqualTo(1000)
+    }
+    
+    saveButton.snp.makeConstraints { make in
+      make.top.equalTo(collectionView.snp.bottom).offset(30)
+      make.leading.trailing.equalToSuperview().inset(24)
+      make.bottom.equalToSuperview().inset(39)
+    }
+  }
+  
+  private func makeDayButton(_ day: Days) -> UIButton {
+    let button = UIButton()
+    button.setTitle(day.description, for: .normal)
+    button.layer.masksToBounds = true
+    button.layer.cornerCurve = .circular
+    button.layer.cornerRadius = Constants.dayButtonSize.height / 2
+    button.titleLabel?.font = Fonts.SpoqaHanSansNeo.medium.font(size: 13)
+
+    button.accessibilityIdentifier = day.description
+    
+    button.setBackgroundColor(Colors.g1.color, for: .normal)
+    button.setTitleColor(Colors.g4.color, for: .normal)
+    button.setBackgroundColor(Colors.blueL1.color, for: .selected)
+    button.setTitleColor(Colors.blue.color, for: .selected)
+    return button
+  }
+  
+}
+
+
+// MARK: - CollectionView Layout
+
+extension TodoFilterSheetView {
+  private func configureCollectionView() {
+    collectionView = UICollectionView(
+      frame: .zero,
+      collectionViewLayout: configureCollectionViewLayout()
+    )
+    
+    collectionView.isPrefetchingEnabled = false
+    collectionView.backgroundColor = Colors.white.color
+    collectionView.isScrollEnabled = true
+  }
+  
+  private func configureCollectionViewLayout() -> UICollectionViewLayout {
+    let sectionProvider = { [weak self] (
+      sectionIndex: Int,
+      layoutEnvironment: NSCollectionLayoutEnvironment
+    ) -> NSCollectionLayoutSection? in
+      guard
+        let sectionKind = SECTION(rawValue: sectionIndex),
+        let self = self
+      else {
+        return nil
+      }
+      
+      var section: NSCollectionLayoutSection
+      
+      switch sectionKind {
+      case .homies:
+        section = self.createSection()
+      }
+      return section
+      
+    }
+    return UICollectionViewCompositionalLayout(sectionProvider: sectionProvider)
+  }
+  
+  private func createSection() -> NSCollectionLayoutSection {
+    let itemSize = NSCollectionLayoutSize(
+      widthDimension: .estimated(1),
+      heightDimension: .fractionalHeight(1)
+    )
+    
+    let item = NSCollectionLayoutItem(layoutSize: itemSize)
+    
+    item.edgeSpacing = NSCollectionLayoutEdgeSpacing(
+      leading: .fixed(8),
+      top: nil,
+      trailing: .fixed(8),
+      bottom: nil
+    )
+    
+    let groupSize = NSCollectionLayoutSize(
+      widthDimension: .estimated(1),
+      heightDimension: .absolute(26)
+    )
+    
+    let group = NSCollectionLayoutGroup.horizontal(
+      layoutSize: groupSize,
+      subitems: [item]
+    )
+    
+    group.edgeSpacing = NSCollectionLayoutEdgeSpacing(
+      leading: nil,
+      top: nil,
+      trailing: nil,
+      bottom: nil
+    )
+    
+    let section = NSCollectionLayoutSection(group: group)
+    section.orthogonalScrollingBehavior = .continuous
+    section.contentInsets = NSDirectionalEdgeInsets(
+      top: Constants.verticalMargin,
+      leading: Constants.horizontalMargin,
+      bottom: Constants.verticalMargin,
+      trailing: Constants.horizontalMargin
+    )
+    
+    return section
+  }
+}
+// MARK: - CollectionView DataSources
+
+extension TodoFilterSheetView {
+  
+  private func applyHomiesSnapShot(_ homies: [HomieCellModel]) {
+    var snapShot = NSDiffableDataSourceSectionSnapshot<ITEM>()
+    let items = homies.map {
+      ITEM.homie($0)
+    }
+    snapShot.append(items)
+    dataSource.apply(snapShot, to: .homies)
+  }
+  
+  private func applyInitialSnapshot() {
+    let sections = SECTION.allCases
+    snapShot = SnapShot()
+    snapShot.appendSections(sections)
+    dataSource.apply(snapShot, animatingDifferences: false)
+  }
+  
+  private func configureDataSource() {
+    let homieCellRegistration = CellRegistration<HomieCell, HomieCellModel> { (cell, indexPath, model) in
+      cell.configure(model)
+    }
+    
+    dataSource = DataSource(
+      collectionView: collectionView) {( collectionView, indexPath, item) -> UICollectionViewCell? in
+        
+        switch item {
+          
+        case .homie(let homie):
+          return collectionView.dequeueConfiguredReusableCell(
+            using: homieCellRegistration,
+            for: indexPath,
+            item: homie
+          )
+        }
+      }
+  }
+}

--- a/Hous-iOS-release.xcodeproj/project.pbxproj
+++ b/Hous-iOS-release.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		B5265D8D2A0EAF440097D147 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5265D8C2A0EAF440097D147 /* Constant.swift */; };
 		B5265D912A0EB48C0097D147 /* RulesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5265D902A0EB48C0097D147 /* RulesViewController.swift */; };
 		B5265D942A0EB7FA0097D147 /* HousRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5265D932A0EB7FA0097D147 /* HousRule.swift */; };
+		B528538F2B9B602D00D96B0D /* SharePlayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B528538E2B9B602D00D96B0D /* SharePlayService.swift */; };
 		B52EEE892A10C26A00518C8F /* HousMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52EEE882A10C26A00518C8F /* HousMenu.swift */; };
 		B52EEE8B2A10CDE100518C8F /* UIControl+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52EEE8A2A10CDE100518C8F /* UIControl+Extension.swift */; };
 		B53F0FBC2910263A004F1872 /* EditRuleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53F0FBB2910263A004F1872 /* EditRuleViewController.swift */; };
@@ -485,6 +486,7 @@
 		B5265D8C2A0EAF440097D147 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		B5265D902A0EB48C0097D147 /* RulesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesViewController.swift; sourceTree = "<group>"; };
 		B5265D932A0EB7FA0097D147 /* HousRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HousRule.swift; sourceTree = "<group>"; };
+		B528538E2B9B602D00D96B0D /* SharePlayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharePlayService.swift; sourceTree = "<group>"; };
 		B52EEE882A10C26A00518C8F /* HousMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HousMenu.swift; sourceTree = "<group>"; };
 		B52EEE8A2A10CDE100518C8F /* UIControl+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl+Extension.swift"; sourceTree = "<group>"; };
 		B53F0FBB2910263A004F1872 /* EditRuleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRuleViewController.swift; sourceTree = "<group>"; };
@@ -501,6 +503,9 @@
 		B54D3A012919707100DA3A95 /* RepresentingBadgeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepresentingBadgeCollectionViewCell.swift; sourceTree = "<group>"; };
 		B54D3A032919708400DA3A95 /* BadgeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeCollectionViewCell.swift; sourceTree = "<group>"; };
 		B54D3A052919810D00DA3A95 /* BadgeViewModel.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = BadgeViewModel.swift; sourceTree = "<group>"; tabWidth = 2; };
+		B5684A662B988ED0007739C7 /* Hous-iOS-releaseDebug(Staging).entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Hous-iOS-releaseDebug(Staging).entitlements"; sourceTree = "<group>"; };
+		B5684A672B989BBA007739C7 /* Hous-iOS-releaseDebug(Development).entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Hous-iOS-releaseDebug(Development).entitlements"; sourceTree = "<group>"; };
+		B5684A682B98AD9C007739C7 /* Hous-iOS-releaseRelease(Development).entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Hous-iOS-releaseRelease(Development).entitlements"; sourceTree = "<group>"; };
 		B5689CBA294F3F48006D20F5 /* monday.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = monday.json; sourceTree = "<group>"; };
 		B58FF3842A0EC5C600EB4E38 /* RuleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleCollectionViewCell.swift; sourceTree = "<group>"; };
 		B58FF3872A0ECCA700EB4E38 /* RuleRespository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleRespository.swift; sourceTree = "<group>"; };
@@ -823,6 +828,9 @@
 		777C665F28A74A62000BECEA /* Hous-iOS-release */ = {
 			isa = PBXGroup;
 			children = (
+				B5684A682B98AD9C007739C7 /* Hous-iOS-releaseRelease(Development).entitlements */,
+				B5684A672B989BBA007739C7 /* Hous-iOS-releaseDebug(Development).entitlements */,
+				B5684A662B988ED0007739C7 /* Hous-iOS-releaseDebug(Staging).entitlements */,
 				773BABB629D1753700ABAACD /* Test */,
 				770B959428F159CE00C8C945 /* Services */,
 				77067FFC28DDE65B0082A7E7 /* Hous-iOS-release.entitlements */,
@@ -932,6 +940,7 @@
 				B856700028C88C3F00B49984 /* Profile */,
 				B8566FFE28C88C3200B49984 /* TabBar */,
 				77B1681D28ABC7EA00E1E512 /* Splash */,
+				B528538E2B9B602D00D96B0D /* SharePlayService.swift */,
 			);
 			path = Scene;
 			sourceTree = "<group>";
@@ -2104,6 +2113,7 @@
 				9BDBAD7A29241E1A0096FE38 /* MateProfileMainImageCollectionViewCell.swift in Sources */,
 				B856701928C9A03500B49984 /* EnterInfoViewController.swift in Sources */,
 				77C67C4D299F85660011C837 /* LoadingView.swift in Sources */,
+				B528538F2B9B602D00D96B0D /* SharePlayService.swift in Sources */,
 				B84EA6A628D61A5400C92FCD /* TodoView.swift in Sources */,
 				B54D3A042919708400DA3A95 /* BadgeCollectionViewCell.swift in Sources */,
 				9B2F46952923A918002D9BD2 /* ProfileEditViewModel.swift in Sources */,
@@ -3295,7 +3305,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = "Hous-iOS-release/Hous-iOS-release.entitlements";
+				CODE_SIGN_ENTITLEMENTS = "Hous-iOS-release/Hous-iOS-releaseDebug(Development).entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 9;
@@ -3332,7 +3342,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = "Hous-iOS-release/Hous-iOS-release.entitlements";
+				CODE_SIGN_ENTITLEMENTS = "Hous-iOS-release/Hous-iOS-releaseRelease(Development).entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
@@ -3434,7 +3444,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = "Hous-iOS-release/Hous-iOS-release.entitlements";
+				CODE_SIGN_ENTITLEMENTS = "Hous-iOS-release/Hous-iOS-releaseDebug(Staging).entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 9;

--- a/Hous-iOS-release.xcodeproj/project.pbxproj
+++ b/Hous-iOS-release.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		9BF9AD74291FBA62006A0BDE /* ProfileTestCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF9AD73291FBA62006A0BDE /* ProfileTestCollectionViewCell.swift */; };
 		9BF9AD76291FC804006A0BDE /* ProfileTestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF9AD75291FC804006A0BDE /* ProfileTestModel.swift */; };
 		B50DD01F2A9394100054B357 /* AddEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50DD01E2A9394100054B357 /* AddEditViewModel.swift */; };
+		B50E96E92B82654100312823 /* UIView+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50E96E82B82654100312823 /* UIView+Combine.swift */; };
 		B51383152A15FD3B00167728 /* AddEditRuleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51383142A15FD3B00167728 /* AddEditRuleViewController.swift */; };
 		B5265D8D2A0EAF440097D147 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5265D8C2A0EAF440097D147 /* Constant.swift */; };
 		B5265D912A0EB48C0097D147 /* RulesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5265D902A0EB48C0097D147 /* RulesViewController.swift */; };
@@ -479,6 +480,7 @@
 		9BF9AD75291FC804006A0BDE /* ProfileTestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTestModel.swift; sourceTree = "<group>"; };
 		9BF9AD7729201812006A0BDE /* ProfileTestInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTestInfoViewController.swift; sourceTree = "<group>"; };
 		B50DD01E2A9394100054B357 /* AddEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditViewModel.swift; sourceTree = "<group>"; };
+		B50E96E82B82654100312823 /* UIView+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Combine.swift"; sourceTree = "<group>"; };
 		B51383142A15FD3B00167728 /* AddEditRuleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditRuleViewController.swift; sourceTree = "<group>"; };
 		B5265D8C2A0EAF440097D147 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		B5265D902A0EB48C0097D147 /* RulesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesViewController.swift; sourceTree = "<group>"; };
@@ -1519,6 +1521,7 @@
 				B52EEE8A2A10CDE100518C8F /* UIControl+Extension.swift */,
 				B83D6D1C2A53D28F00E8DB11 /* UIControl+Combine.swift */,
 				B59481012A9F8C61007971A8 /* UIImage+Extension.swift */,
+				B50E96E82B82654100312823 /* UIView+Combine.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -2071,6 +2074,7 @@
 				B85C0B5E2940B11A00784FCB /* GrayBackgroundTextField.swift in Sources */,
 				B8249A5529116E69008005DE /* MemEmptyListCell.swift in Sources */,
 				9B4EE80F294CED49002F97C2 /* UITableView+Extension.swift in Sources */,
+				B50E96E92B82654100312823 /* UIView+Combine.swift in Sources */,
 				77EB720629253FBE00032776 /* AssigneeCell.swift in Sources */,
 				B80BBA85290A534800E4916F /* MemberCollectionViewCellReactor.swift in Sources */,
 				B856700728C88C6F00B49984 /* ProfileViewController.swift in Sources */,

--- a/Hous-iOS-release/Extension/UIView+Combine.swift
+++ b/Hous-iOS-release/Extension/UIView+Combine.swift
@@ -1,0 +1,85 @@
+//
+//  UIView+Combine.swift
+//  Hous-iOS-release
+//
+//  Created by 김민재 on 2/19/24.
+//
+
+import UIKit
+import Combine
+
+class GestureSubscription<S: Subscriber>: Subscription where S.Input == Void, S.Failure == Never {
+    private var subscriber: S?
+    private var gestureType: GestureType
+    private var view: UIView
+    init(subscriber: S, view: UIView, gestureType: GestureType) {
+        self.subscriber = subscriber
+        self.view = view
+        self.gestureType = gestureType
+        configureGesture(gestureType)
+    }
+    private func configureGesture(_ gestureType: GestureType) {
+        let gesture = gestureType.get()
+        gesture.addTarget(self, action: #selector(handler))
+        view.addGestureRecognizer(gesture)
+    }
+    func request(_ demand: Subscribers.Demand) { }
+    func cancel() {
+        subscriber = nil
+    }
+    @objc
+    private func handler() {
+        _ = subscriber?.receive(())
+    }
+}
+
+struct GesturePublisher: Publisher {
+    typealias Output = Void
+    typealias Failure = Never
+    private let view: UIView
+    private let gestureType: GestureType
+    init(view: UIView, gestureType: GestureType) {
+        self.view = view
+        self.gestureType = gestureType
+    }
+    func receive<S>(subscriber: S) where S: Subscriber,
+    GesturePublisher.Failure == S.Failure, GesturePublisher.Output
+    == S.Input {
+        let subscription = GestureSubscription(
+            subscriber: subscriber,
+            view: view,
+            gestureType: gestureType
+        )
+        subscriber.receive(subscription: subscription)
+    }
+}
+enum GestureType {
+    case tap(UITapGestureRecognizer = .init())
+    case swipe(UISwipeGestureRecognizer = .init())
+    case longPress(UILongPressGestureRecognizer = .init())
+    case pan(UIPanGestureRecognizer = .init())
+    case pinch(UIPinchGestureRecognizer = .init())
+    case edge(UIScreenEdgePanGestureRecognizer = .init())
+    func get() -> UIGestureRecognizer {
+        switch self {
+        case let .tap(tapGesture):
+            return tapGesture
+        case let .swipe(swipeGesture):
+            return swipeGesture
+        case let .longPress(longPressGesture):
+            return longPressGesture
+        case let .pan(panGesture):
+            return panGesture
+        case let .pinch(pinchGesture):
+            return pinchGesture
+        case let .edge(edgePanGesture):
+            return edgePanGesture
+       }
+    }
+}
+
+extension UIView {
+    var tapPublisher: GesturePublisher {
+        .init(view: self, gestureType: .tap())
+    }
+}

--- a/Hous-iOS-release/Hous-iOS-releaseDebug(Development).entitlements
+++ b/Hous-iOS-release/Hous-iOS-releaseDebug(Development).entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+	<key>com.apple.developer.group-session</key>
+	<true/>
+	<key>com.apple.developer.networking.wifi-info</key>
+	<true/>
+</dict>
+</plist>

--- a/Hous-iOS-release/Hous-iOS-releaseDebug(Staging).entitlements
+++ b/Hous-iOS-release/Hous-iOS-releaseDebug(Staging).entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+	<key>com.apple.developer.group-session</key>
+	<true/>
+	<key>com.apple.developer.networking.wifi-info</key>
+	<true/>
+</dict>
+</plist>

--- a/Hous-iOS-release/Hous-iOS-releaseRelease(Development).entitlements
+++ b/Hous-iOS-release/Hous-iOS-releaseRelease(Development).entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+	<key>com.apple.developer.group-session</key>
+	<true/>
+	<key>com.apple.developer.networking.wifi-info</key>
+	<true/>
+</dict>
+</plist>

--- a/Hous-iOS-release/Repository/Todo/TodoRepository.swift
+++ b/Hous-iOS-release/Repository/Todo/TodoRepository.swift
@@ -10,6 +10,7 @@ import Network
 import RxSwift
 import RxCocoa
 import BottomSheetKit
+import Combine
 
 public enum TodoRepositoryEvent {
   case date(String)
@@ -35,6 +36,7 @@ public enum TodoRepositoryEvent {
 }
 
 public protocol TodoRepository {
+  var subjectEvent: PassthroughSubject<TodoRepositoryEvent, Never> { get }
   var event: PublishSubject<TodoRepositoryEvent> { get }
   func fetchTodo()
   func fetchModifyingTodo(_ id: Int)
@@ -51,6 +53,7 @@ public protocol TodoRepository {
 }
 
 public final class TodoRepositoryImp: BaseService, TodoRepository {
+  public var subjectEvent = PassthroughSubject<TodoRepositoryEvent, Never>()
   public var event = PublishSubject<TodoRepositoryEvent>()
 
   public func fetchTodo() {
@@ -148,6 +151,7 @@ public final class TodoRepositoryImp: BaseService, TodoRepository {
           status: res?.status,
           message: res?.message
         )
+        self.subjectEvent.send(.sendError(errorModel))
         self.event.onNext(.sendError(errorModel))
         return
       }
@@ -160,7 +164,7 @@ public final class TodoRepositoryImp: BaseService, TodoRepository {
           isExpanded: false
         )
       }
-
+      self.subjectEvent.send(.getAssignees(homies))
       self.event.onNext(.getAssignees(homies))
     }
   }

--- a/Hous-iOS-release/Scene/MainHome/ViewControllers/MainHomeViewController.swift
+++ b/Hous-iOS-release/Scene/MainHome/ViewControllers/MainHomeViewController.swift
@@ -15,6 +15,23 @@ import Network
 import RxGesture
 import BottomSheetKit
 
+import GroupActivities
+
+struct CodeModel: Codable {
+  let code: String
+}
+
+struct ShareCodeActivity: GroupActivity {
+  static let activityIdentifier: String = "com.hous-ios"
+  var metadata: GroupActivityMetadata {
+    var metadata = GroupActivityMetadata()
+    metadata.title = "초대 코드를 받으세요"
+    metadata.subtitle = "초대 코드"
+    metadata.type = GroupActivityMetadata.ActivityType.generic
+    return metadata
+  }
+}
+
 protocol MainHomeViewControllerDelegate: AnyObject {
   func editHousName(initname: String)
 }
@@ -28,6 +45,8 @@ final class MainHomeViewController: BaseViewController, LoadingPresentable {
   }
 
   // MARK: - Vars & Lets
+  private let sharePlayService = SharePlayService.shared
+
   private let viewModel: MainHomeViewModel
   private let disposeBag = DisposeBag()
   var delegate: MainHomeViewControllerDelegate?
@@ -59,6 +78,7 @@ final class MainHomeViewController: BaseViewController, LoadingPresentable {
     configUI()
     configCollectionView()
     bind()
+    sharePlayService.setSharePlay()
   }
 
   init(viewModel: MainHomeViewModel) {
@@ -214,6 +234,7 @@ final class MainHomeViewController: BaseViewController, LoadingPresentable {
 
       cell.editButton.rx.tap.asDriver()
         .drive(onNext: { [weak self] in
+          self?.sharePlayService.activate()
 //          self?.delegate?.editHousName(initname: todos.roomName)
            self?.navigationController?.pushViewController(
                      EditHousNameViewController(roomName: todos.roomName),
@@ -306,8 +327,9 @@ final class MainHomeViewController: BaseViewController, LoadingPresentable {
 
     output.roomCode
       .drive(onNext: { str in
-        UIPasteboard.general.string = str
-        Toast.show(message: "초대코드가 복사되었습니다", controller: self)
+        self.sharePlayService.send(code: str)
+//        UIPasteboard.general.string = str
+//        Toast.show(message: "초대코드가 복사되었습니다", controller: self)
       })
       .disposed(by: disposeBag)
 

--- a/Hous-iOS-release/Scene/Onboarding/EnterRoom/EnterRoomViewController.swift
+++ b/Hous-iOS-release/Scene/Onboarding/EnterRoom/EnterRoomViewController.swift
@@ -44,8 +44,15 @@ extension EnterRoomViewController {
   private func bindAction(_ reactor: EnterRoomViewReactor) {
     sharePlayService.codeSubject
       .observe(on: MainScheduler.instance)
-      .map { Reactor.Action.didTapExistRoomButton(code: $0) }
-      .bind(to: reactor.action)
+      .withUnretained(self)
+      .subscribe(onNext: { owner, code in
+        let serviceProvider = ServiceProvider()
+        let reactor = EnterRoomCodeViewReactor(provider: serviceProvider, code: code)
+        let vc = EnterRoomCodeViewController(reactor)
+        owner.mainView.existRoomView.animateClick {
+          owner.navigationController?.pushViewController(vc, animated: true)
+        }
+      })
       .disposed(by: disposeBag)
     
     mainView.newRoomView.rx.tapGesture()

--- a/Hous-iOS-release/Scene/Onboarding/EnterRoom/EnterRoomViewReactor.swift
+++ b/Hous-iOS-release/Scene/Onboarding/EnterRoom/EnterRoomViewReactor.swift
@@ -13,17 +13,17 @@ final class EnterRoomViewReactor: Reactor {
 
   enum Action {
     case didTapNewRoomButton
-    case didTapExistRoomButton
+    case didTapExistRoomButton(code: String?)
   }
 
   enum Mutation {
     case setNewRoomTransition
-    case setExistRoomTransition
+    case setExistRoomTransition(code: String?)
   }
 
   struct State {
     var newRoomTransition: Bool = false
-    var existRoomTransition: Bool = false
+    var existRoomTransition: (Bool, String?) = (false, nil)
   }
 
   let initialState = State()
@@ -32,8 +32,11 @@ final class EnterRoomViewReactor: Reactor {
     switch action {
     case .didTapNewRoomButton:
       return .just(Mutation.setNewRoomTransition)
-    case .didTapExistRoomButton:
-      return .just(Mutation.setExistRoomTransition)
+    case .didTapExistRoomButton(let code):
+      if let code {
+        return .just(Mutation.setExistRoomTransition(code: code))
+      }
+      return .just(Mutation.setExistRoomTransition(code: nil))
     }
   }
 
@@ -41,12 +44,18 @@ final class EnterRoomViewReactor: Reactor {
 
     var newState = state
     newState.newRoomTransition = false
-    newState.existRoomTransition = false
+    newState.existRoomTransition = (false, nil)
     switch mutation {
     case .setNewRoomTransition:
       newState.newRoomTransition = !currentState.newRoomTransition
-    case .setExistRoomTransition:
-      newState.existRoomTransition = !currentState.existRoomTransition
+    case .setExistRoomTransition(let code):
+      if let code {
+        newState.existRoomTransition = (!currentState.existRoomTransition.0, code)
+      } else {
+        newState.existRoomTransition = (!currentState.existRoomTransition.0, nil)
+      }
+      
+      
     }
     return newState
   }

--- a/Hous-iOS-release/Scene/Onboarding/EnterRoomTextField/EnterRoomCodeViewController.swift
+++ b/Hous-iOS-release/Scene/Onboarding/EnterRoomTextField/EnterRoomCodeViewController.swift
@@ -48,8 +48,8 @@ final class EnterRoomCodeViewController: UIViewController, View {
   }
 
   func bind(reactor: EnterRoomCodeViewReactor) {
-    bindAction(reactor)
     bindState(reactor)
+    bindAction(reactor)
   }
 }
 

--- a/Hous-iOS-release/Scene/Onboarding/EnterRoomTextField/EnterRoomCodeViewController.swift
+++ b/Hous-iOS-release/Scene/Onboarding/EnterRoomTextField/EnterRoomCodeViewController.swift
@@ -69,6 +69,10 @@ extension EnterRoomCodeViewController {
   }
 
   private func bindState(_ reactor: Reactor) {
+    
+    reactor.state.map { $0.roomCode }
+      .bind(to: mainView.textField.rx.text)
+      .disposed(by: disposeBag)
 
     reactor.state.map { $0.isButtonEnable }
       .bind(to: mainView.enterRoomButton.rx.isEnabled)

--- a/Hous-iOS-release/Scene/Onboarding/EnterRoomTextField/EnterRoomCodeViewReactor.swift
+++ b/Hous-iOS-release/Scene/Onboarding/EnterRoomTextField/EnterRoomCodeViewReactor.swift
@@ -35,7 +35,7 @@ final class EnterRoomCodeViewReactor: Reactor {
   enum Action {
     case enterRoomCode(String?)
     case tapEnterRoom(String?)
-    case initial
+    case initial(String?)
   }
 
   enum Mutation {
@@ -48,7 +48,7 @@ final class EnterRoomCodeViewReactor: Reactor {
     case setPresentPopupFlag(Bool?)
     case setEnterRoomFlag(Bool?) 
     case setError(Int?)
-    case setInitial
+    case setInitial(String?)
   }
 
   struct State {
@@ -81,8 +81,8 @@ final class EnterRoomCodeViewReactor: Reactor {
       provider.enterRoomRepository.checkExistRoom(code)
       return .empty()
 
-    case .initial:
-      return .just(.setInitial)
+    case .initial(let code):
+      return .just(.setInitial(code))
     }
   }
 

--- a/Hous-iOS-release/Scene/Onboarding/EnterRoomTextField/EnterRoomCodeViewReactor.swift
+++ b/Hous-iOS-release/Scene/Onboarding/EnterRoomTextField/EnterRoomCodeViewReactor.swift
@@ -21,9 +21,15 @@ final class EnterRoomCodeViewReactor: Reactor {
    */
 
   private let provider: ServiceProviderType
+  var initialState: State
 
-  init(provider: ServiceProviderType) {
+  init(provider: ServiceProviderType, code: String? = nil) {
     self.provider = provider
+    if let code {
+      initialState = State(roomCode: code)
+    } else {
+      initialState = State()
+    }
   }
 
   enum Action {
@@ -55,9 +61,13 @@ final class EnterRoomCodeViewReactor: Reactor {
     @Pulse var presentPopupFlag: Bool?
     @Pulse var enterRoomFlag: Bool?
     var error: Int? = nil
+    
+    init(roomCode: String? = nil) {
+      self.roomCode = roomCode
+    }
   }
 
-  let initialState = State()
+  
 
   func mutate(action: Action) -> Observable<Mutation> {
     switch action {

--- a/Hous-iOS-release/Scene/Serach/SearchBarViewController.swift
+++ b/Hous-iOS-release/Scene/Serach/SearchBarViewController.swift
@@ -106,18 +106,37 @@ extension SearchBarViewController {
 
   private func bindOutput() {
 
+    filterView.tapPublisher
+      .sink { _ in
+        // TODO: 필터 바텀시트 띄우기.
+        print("filter button tapped!")
+      }
+      .store(in: &subscriptions)
+
     viewModel.$searchedList
       .compactMap { $0 }
       .sink { [weak self] list in
         guard let self = self else { return }
         self.applySnapshot(with: list)
+        self.filterView.resultCnt = list.count
       }
       .store(in: &subscriptions)
 
     viewModel.$floatingBtnTapped
-      .compactMap { $0 }
-      .sink { type in
-        print("\(type) 버튼눌림 버튼눌림 버튼눌림")
+      .sink { [weak self] homies in
+        guard let self else { return }
+
+        let state = UpdateTodoReactor.State(
+          todoHomies: homies ?? []
+        )
+        let provider = ServiceProvider()
+        let reactor = UpdateTodoReactor(
+          provider: provider,
+          state: state
+        )
+
+        let viewController = UpdateTodoViewController(reactor)
+        self.navigationController?.pushViewController(viewController, animated: true)
       }
       .store(in: &subscriptions)
   }

--- a/Hous-iOS-release/Scene/Serach/SearchBarViewModel.swift
+++ b/Hous-iOS-release/Scene/Serach/SearchBarViewModel.swift
@@ -36,7 +36,9 @@ final class SearchBarViewModel {
   @Published private(set) var selectedTodo: TodoModel?
   // @Published private(set) var selectedRule: RuleModel?
 
-  @Published private(set) var floatingBtnTapped: SearchType?
+  @Published private(set) var floatingBtnTapped: [UpdateTodoHomieModel]?
+
+  private var homies: [UpdateTodoHomieModel]?
 
   // MARK: - Input -> Output
   func transform(input: Input) {
@@ -44,6 +46,7 @@ final class SearchBarViewModel {
       .sink { [unowned self] type in
         if type == .todo {
           self.provider.searchRepository.fetchFilteredTodo(with: nil, of: nil)
+          self.provider.todoRepository.fetchHomie()
         }
       }
       .store(in: &subscriptions)
@@ -59,8 +62,8 @@ final class SearchBarViewModel {
       .store(in: &subscriptions)
 
     input.didTapFloatingBtn
-      .sink { [unowned self] type in
-        self.floatingBtnTapped = type
+      .sink { [unowned self] _ in
+        self.floatingBtnTapped = self.homies
       }
       .store(in: &subscriptions)
   }
@@ -83,6 +86,18 @@ extension SearchBarViewModel {
           self.selectedTodo = detail
         case let .sendError(err):
           print(err?.message ?? "")
+        }
+      }
+      .store(in: &subscriptions)
+
+    provider.todoRepository.subjectEvent
+      .sink { [weak self] value in
+        guard let self else { return }
+        switch value {
+        case .getAssignees(let homies):
+          self.homies = homies
+        default:
+          break
         }
       }
       .store(in: &subscriptions)

--- a/Hous-iOS-release/Scene/SharePlayService.swift
+++ b/Hous-iOS-release/Scene/SharePlayService.swift
@@ -37,6 +37,7 @@ final class SharePlayService {
 
       // receiving
       for await (code, _) in messenger.messages(of: CodeModel.self) {
+        print(code.code)
         self.codeSubject.onNext(code.code)
       }
     }

--- a/Hous-iOS-release/Scene/SharePlayService.swift
+++ b/Hous-iOS-release/Scene/SharePlayService.swift
@@ -1,0 +1,63 @@
+//
+//  SharePlayService.swift
+//  Hous-iOS-release
+//
+//  Created by 김민재 on 3/9/24.
+//
+
+import Foundation
+import GroupActivities
+import RxSwift
+
+final class SharePlayService {
+
+  static let shared = SharePlayService()
+
+  private init() {}
+
+  let codeSubject = PublishSubject<String>()
+
+  private var messenger: GroupSessionMessenger?
+  var tasks = Set<Task<Void, Never>>()
+
+  func setSharePlay() {
+    Task {
+      for await session in ShareCodeActivity.sessions() {
+        self.configureGroupSession(session)
+      }
+    }
+
+  }
+
+  func configureGroupSession(_ session: GroupSession<ShareCodeActivity>) {
+    let messenger = GroupSessionMessenger(session: session)
+    self.messenger = messenger
+
+    let task = Task.detached {
+
+      // receiving
+      for await (code, _) in messenger.messages(of: CodeModel.self) {
+        self.codeSubject.onNext(code.code)
+      }
+    }
+    tasks.insert(task)
+    session.join()
+
+  }
+
+  func activate() {
+    Task {
+      do {
+        _ = try await ShareCodeActivity().activate()
+      } catch {
+        print("Failed to activate DrawTogether activity: \(error)")
+      }
+    }
+  }
+
+  func send(code: String) {
+    Task {
+      try await self.messenger?.send(CodeModel(code: code))
+    }
+  }
+}

--- a/Hous-iOS-release/Scene/Todo/FilterTodo/Controller/FilterView.swift
+++ b/Hous-iOS-release/Scene/Todo/FilterTodo/Controller/FilterView.swift
@@ -8,7 +8,7 @@
 import UIKit
 import HousUIComponent
 
-class FilterView: UIView {
+final class FilterView: UIView {
 
   var resultCnt: Int = 0 {
     didSet {

--- a/Network/Sources/Network/API/TodoAPI/MainTodoService.swift
+++ b/Network/Sources/Network/API/TodoAPI/MainTodoService.swift
@@ -42,32 +42,32 @@ extension TodoService: TargetType {
     switch self {
       // MARK: main
     case .getTodos:
-      return "/todos/main"
+      return "/v1/todos/main"
     case let .checkTodo(todoId, _):
-      return "/todo/\(todoId)/check"
+      return "/v1/todo/\(todoId)/check"
     case let .getTodoSummary(todoId):
-      return "/todo/\(todoId)/summary"
+      return "/v1/todo/\(todoId)/summary"
     case let .deleteTodo(todoId):
-      return "/todo/\(todoId)"
+      return "/v1/todo/\(todoId)"
     case .getOnlyMyTodo:
       return "todos/me"
       // MARK: 추가 / 수정
     case .getAssignees:
-      return "/todo"
+      return "/v1/todo"
     case .getModifyTodoID(let id):
-      return "todo/\(id)"
+      return "/v1todo/\(id)"
     case .updateTodo(let id, _):
       guard let id = id else {
-        return "/todo"
+        return "/v1/todo"
       }
-      return "/todo/\(id)"
+      return "/v1/todo/\(id)"
 
       // MARK: 요일별
     case .getDaysOfWeekTodos:
-      return "todos/day"
+      return "/v1/todos/day"
       // MARK: 멤버별
     case .getMemberTodos:
-      return "todos/member"
+      return "/v1/todos/member"
     }
   }
 

--- a/Network/Sources/Network/API/TodoAPI/TodoService.swift
+++ b/Network/Sources/Network/API/TodoAPI/TodoService.swift
@@ -27,9 +27,9 @@ extension NewTodoService: TargetType {
   public var path: String {
     switch self {
     case .getTodoByFilter:
-      return "/todos"
+      return "/v1/todos"
     case .getTodoDetail(let todoId):
-        return "/todo/\(todoId)/summary"
+        return "/v1/todo/\(todoId)/summary"
     }
   }
 


### PR DESCRIPTION
## 🌱 작업한 내용
처음 방생성 이후를 제외한 기존 방 초대코드 뎁스는 아래와 같았습니다.
**[ ✉️공유자 ]**
1. 앱을 킨다
2. 메인홈에서 초대코드 복사
3. 지인 카톡방에 들어간다
4. 초대코드를 공유한다

**[ 📮수신자 ]**
1. 카톡방의 초대코드를 복사한다.
2. 앱을 킨다
8. 방에 입장하기를 누른다
9. 코드를 쓰고 입장한다.

초대코드를 클립보드에 복사해서 직접 공유하는 방식이 좋지 않게 느껴졌고, WWDC23의 세션중 하단 링크 영상을 보고 영감을 얻었습니다.
https://developer.apple.com/videos/play/wwdc2023/10239/


수정 이후 현재 초대 방식입니다.
**[ ✉️ 공유자 ]**
1. Facetime을 통해 지인들과 Group을 만든다.
2. 앱을 킨다
3. 액티비티 버튼을 누른 후 코드 복사 버튼을 누른다.

**[ 📮수신자 ]**
1. 방 입장하기 버튼을 누른다.
- 방 입장여부에 대한 판단을 위해 해당 뎁스는 남겨놓았습니다.

## 🌱 PR Point

### SharePlayService객체를 싱글톤으로 한 이유
SharePlayService를 DI를 통해 주입하게 되면 생성되는 Session이 달라 공유가 이뤄지지 않는 문제가 발생했습니다. 앱내에서 Session을 동일한 Session을 유지하도록 하기 위해 싱글톤을 사용했습니다. 하지만 로그인 이후 해당 객체가 유의미하게 사용될 수 있는 기능이 현재로서는 존재하지 않아 개선의 여지가 있습니다.

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 작동화면 | ![IMG_0309](https://github.com/Hous-Release/hous-iOS/assets/60292150/5b06ece7-076a-4967-864c-1782651e9540) |

## 📮 관련 이슈

- Resolved: #224
